### PR TITLE
Introduce difficulty options and challenge mode

### DIFF
--- a/lock-game/src/App.css
+++ b/lock-game/src/App.css
@@ -25,6 +25,35 @@
   font-size: 2rem;
   padding: 0.5rem;
   width: 2rem;
+  transition: transform 0.3s ease;
+}
+
+.wheel.spin .digit-display {
+  transform: rotateX(360deg);
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.attempt-text {
+  font-size: 1rem;
+}
+
+.footer {
+  opacity: 0.5;
+  font-size: 0.8rem;
+  margin-top: 2rem;
+}
+
+@media (max-width: 600px) {
+  .wheels {
+    flex-wrap: wrap;
+  }
 }
 
 .history {


### PR DESCRIPTION
## Summary
- allow selecting game mode and difficulty at startup
- add challenge mode with plain text hints
- animate wheel digit changes
- improve mobile layout and add footer credit

## Testing
- `python -m unittest discover -s tests`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688668fc7c0c83279f8ca4836d3fc22d