### PR TITLE
Add Sudoku game and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Kilit Tahmin Oyunu
+# Kilit Tahmin Oyunu ve Sudoku
 
-Bu proje, basit bir sayısal kilit tahmin oyununu React ile sunar. Oyun açıldığında sistem rastgele beş haneli bir şifre belirler. Oyuncu rakamları yukarı/aşağı okları ile değiştirerek tahmin yapar. Toplam deneme hakkı 10'dur.
+Bu proje React ile geliştirilmiş iki farklı oyun içerir: sayısal kilit tahmini ve Sudoku. Kilit oyununda sistem rastgele hanelerden oluşan bir şifre belirler. Oyuncu rakamları yukarı/aşağı okları ile değiştirerek tahmin yapar. Toplam deneme hakkı seçilen zorluğa göre değişir.
+
+Sudoku oyununda üç zorluk seviyesi bulunur. Kolay seviyede 5x5 karelik mini bir Sudoku sunulur ve üç ipucu verilir. Orta seviyede 9x9 standart Sudoku daha fazla açık sayıyla gelir ve yine üç ipucu sağlanır. Zor seviyede 9x9 Sudoku daha az açık sayı içerir, üç yanılma hakkı ve tek ipucu vardır.
 
 Her tahmin sonrası sonuçlar renklerle gösterilir:
 

--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,11 @@
   text-align: center;
   font-family: sans-serif;
   padding: 2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .wheels {
@@ -15,6 +20,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  perspective: 400px;
 }
 
 .wheel button {
@@ -93,4 +99,14 @@
 .status {
   margin-top: 1rem;
   font-weight: bold;
+}
+
+@media (min-width: 800px) {
+  .digit-display {
+    font-size: 3rem;
+  }
+  .digit {
+    font-size: 2rem;
+    width: 2rem;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import './App.css'
+import SudokuGame from './SudokuGame.jsx'
 
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
@@ -27,8 +28,10 @@ function DigitWheel({ value, onChange, disabled }) {
 
 export default function App() {
   const [screen, setScreen] = useState('start')
+  const [gameType, setGameType] = useState('lock') // lock or sudoku
   const [mode, setMode] = useState('easy') // 'easy' or 'challenge'
-  const [difficulty, setDifficulty] = useState('easy') // easy, medium, hard
+  const [difficulty, setDifficulty] = useState('easy') // lock difficulty
+  const [sudokuDifficulty, setSudokuDifficulty] = useState('easy')
 
   const [codeLength, setCodeLength] = useState(4)
   const [maxAttempts, setMaxAttempts] = useState(10)
@@ -40,17 +43,21 @@ export default function App() {
   const finished = status !== ''
 
   const startGame = () => {
-    const lengths = { easy: 4, medium: 5, hard: 6 }
-    const attemptsMap = { easy: 10, medium: 8, hard: 6 }
-    const len = lengths[difficulty]
-    const att = attemptsMap[difficulty]
-    setCodeLength(len)
-    setMaxAttempts(att)
-    setSecret(generateSecret(len))
-    setGuess(Array(len).fill(0))
-    setAttempts([])
-    setStatus('')
-    setScreen('play')
+    if (gameType === 'lock') {
+      const lengths = { easy: 4, medium: 5, hard: 6 }
+      const attemptsMap = { easy: 10, medium: 8, hard: 6 }
+      const len = lengths[difficulty]
+      const att = attemptsMap[difficulty]
+      setCodeLength(len)
+      setMaxAttempts(att)
+      setSecret(generateSecret(len))
+      setGuess(Array(len).fill(0))
+      setAttempts([])
+      setStatus('')
+      setScreen('play')
+    } else {
+      setScreen('sudoku')
+    }
   }
 
   const handleChange = (index, val) => {
@@ -129,35 +136,61 @@ export default function App() {
   }
 
   const handleRestart = () => {
-    setSecret(generateSecret(codeLength))
-    setGuess(Array(codeLength).fill(0))
-    setAttempts([])
-    setStatus('')
+    setScreen('start')
   }
 
   if (screen === 'start') {
     return (
       <div className="app">
-        <h1>Lock Game</h1>
+        <h1>Oyun Seçimi</h1>
         <div className="options">
           <div>
-            <label>Mod: </label>
-            <select value={mode} onChange={(e) => setMode(e.target.value)}>
-              <option value="easy">Lock Game Easy</option>
-              <option value="challenge">Lock Game Challenge</option>
+            <label>Oyun: </label>
+            <select value={gameType} onChange={(e) => setGameType(e.target.value)}>
+              <option value="lock">Lock Game</option>
+              <option value="sudoku">Sudoku</option>
             </select>
           </div>
-          <div>
-            <label>Zorluk: </label>
-            <select value={difficulty} onChange={(e) => setDifficulty(e.target.value)}>
-              <option value="easy">Kolay (4 hane, 10 hak)</option>
-              <option value="medium">Orta (5 hane, 8 hak)</option>
-              <option value="hard">Zor (6 hane, 6 hak)</option>
-            </select>
-          </div>
+          {gameType === 'lock' && (
+            <>
+              <div>
+                <label>Mod: </label>
+                <select value={mode} onChange={(e) => setMode(e.target.value)}>
+                  <option value="easy">Lock Game Easy</option>
+                  <option value="challenge">Lock Game Challenge</option>
+                </select>
+              </div>
+              <div>
+                <label>Zorluk: </label>
+                <select value={difficulty} onChange={(e) => setDifficulty(e.target.value)}>
+                  <option value="easy">Kolay (4 hane, 10 hak)</option>
+                  <option value="medium">Orta (5 hane, 8 hak)</option>
+                  <option value="hard">Zor (6 hane, 6 hak)</option>
+                </select>
+              </div>
+            </>
+          )}
+          {gameType === 'sudoku' && (
+            <div>
+              <label>Zorluk: </label>
+              <select value={sudokuDifficulty} onChange={(e) => setSudokuDifficulty(e.target.value)}>
+                <option value="easy">5x5 Kolay</option>
+                <option value="medium">9x9 Orta</option>
+                <option value="hard">9x9 Zor</option>
+              </select>
+            </div>
+          )}
           <button onClick={startGame}>Başla</button>
         </div>
         <footer className="footer">Mustafa Evleksiz Tarafından geliştirilmiştir</footer>
+      </div>
+    )
+  }
+
+  if (screen === 'sudoku') {
+    return (
+      <div className="app">
+        <SudokuGame difficulty={sudokuDifficulty} onBack={handleRestart} />
       </div>
     )
   }

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -1,0 +1,34 @@
+.sudoku {
+  text-align: center;
+}
+
+.board {
+  border-collapse: collapse;
+  margin: 1rem auto;
+}
+.board td {
+  border: 1px solid #333;
+  width: 2rem;
+  height: 2rem;
+  text-align: center;
+}
+.board input {
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  border: none;
+  font-size: 1rem;
+}
+.prefilled {
+  background: #eee;
+}
+.controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+.status {
+  margin-top: 0.5rem;
+  font-weight: bold;
+}

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import './Sudoku.css'
+
+const data = {
+  easy: {
+    size: 5,
+    hints: 3,
+    puzzle: [
+      [1,2,0,4,5],
+      [4,0,1,0,3],
+      [0,3,4,5,1],
+      [5,1,0,3,0],
+      [3,0,5,1,2]
+    ],
+    solution: [
+      [1,2,3,4,5],
+      [4,5,1,2,3],
+      [2,3,4,5,1],
+      [5,1,2,3,4],
+      [3,4,5,1,2]
+    ]
+  },
+  medium: {
+    size: 9,
+    hints: 3,
+    puzzle: [
+      [5,3,0,0,7,0,0,0,0],
+      [6,0,0,1,9,5,0,0,0],
+      [0,9,8,0,0,0,0,6,0],
+      [8,0,0,0,6,0,0,0,3],
+      [4,0,0,8,0,3,0,0,1],
+      [7,0,0,0,2,0,0,0,6],
+      [0,6,0,0,0,0,2,8,0],
+      [0,0,0,4,1,9,0,0,5],
+      [0,0,0,0,8,0,0,7,9]
+    ],
+    solution: [
+      [5,3,4,6,7,8,9,1,2],
+      [6,7,2,1,9,5,3,4,8],
+      [1,9,8,3,4,2,5,6,7],
+      [8,5,9,7,6,1,4,2,3],
+      [4,2,6,8,5,3,7,9,1],
+      [7,1,3,9,2,4,8,5,6],
+      [9,6,1,5,3,7,2,8,4],
+      [2,8,7,4,1,9,6,3,5],
+      [3,4,5,2,8,6,1,7,9]
+    ]
+  },
+  hard: {
+    size: 9,
+    hints: 1,
+    puzzle: [
+      [0,3,0,0,7,0,0,0,0],
+      [6,0,0,0,0,0,0,4,0],
+      [0,0,0,3,0,0,5,0,0],
+      [8,0,0,0,6,1,0,2,0],
+      [0,0,6,8,0,3,7,0,0],
+      [0,1,0,0,2,0,0,0,6],
+      [0,0,1,5,0,0,0,8,0],
+      [0,0,0,4,1,9,0,0,5],
+      [0,0,0,0,8,0,0,7,9]
+    ],
+    solution: [
+      [5,3,4,6,7,8,9,1,2],
+      [6,7,2,1,9,5,3,4,8],
+      [1,9,8,3,4,2,5,6,7],
+      [8,5,9,7,6,1,4,2,3],
+      [4,2,6,8,5,3,7,9,1],
+      [7,1,3,9,2,4,8,5,6],
+      [9,6,1,5,3,7,2,8,4],
+      [2,8,7,4,1,9,6,3,5],
+      [3,4,5,2,8,6,1,7,9]
+    ]
+  }
+}
+
+export default function SudokuGame({ difficulty, onBack }) {
+  const cfg = data[difficulty]
+  const [board, setBoard] = useState(cfg.puzzle.map(r => [...r]))
+  const [hintsLeft, setHintsLeft] = useState(cfg.hints)
+  const [mistakes, setMistakes] = useState(0)
+  const maxMistakes = difficulty === 'hard' ? 3 : Infinity
+  const finished = board.every((row, r) =>
+    row.every((val, c) => val === cfg.solution[r][c])
+  )
+
+  const handleChange = (r, c, val) => {
+    if (cfg.puzzle[r][c] !== 0 || finished) return
+    const num = parseInt(val, 10)
+    if (!num || num < 1 || num > cfg.size) return
+    const newBoard = board.map(row => [...row])
+    newBoard[r][c] = num
+    if (num !== cfg.solution[r][c]) {
+      if (difficulty === 'hard') {
+        const m = mistakes + 1
+        setMistakes(m)
+        if (m >= maxMistakes) {
+          alert('Kaybettiniz!')
+          onBack()
+          return
+        }
+      }
+    }
+    setBoard(newBoard)
+  }
+
+  const giveHint = () => {
+    if (hintsLeft <= 0 || finished) return
+    const empties = []
+    for (let r = 0; r < cfg.size; r++) {
+      for (let c = 0; c < cfg.size; c++) {
+        if (board[r][c] === 0) empties.push([r, c])
+      }
+    }
+    if (empties.length === 0) return
+    const [r, c] = empties[Math.floor(Math.random() * empties.length)]
+    const newBoard = board.map(row => [...row])
+    newBoard[r][c] = cfg.solution[r][c]
+    setBoard(newBoard)
+    setHintsLeft(hintsLeft - 1)
+  }
+
+  return (
+    <div className="sudoku">
+      <h1>Sudoku</h1>
+      <table className="board">
+        <tbody>
+          {board.map((row, r) => (
+            <tr key={r}>
+              {row.map((cell, c) => (
+                <td key={c} className={cfg.puzzle[r][c] !== 0 ? 'prefilled' : ''}>
+                  {cfg.puzzle[r][c] !== 0 ? (
+                    cfg.puzzle[r][c]
+                  ) : (
+                    <input
+                      value={cell === 0 ? '' : cell}
+                      onChange={e => handleChange(r, c, e.target.value)}
+                    />
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="controls">
+        <button onClick={giveHint} disabled={hintsLeft <= 0}>Ipucu ({hintsLeft})</button>
+        <button onClick={onBack}>Ana Sayfa</button>
+      </div>
+      {difficulty === 'hard' && <p>Hata: {mistakes}/{maxMistakes}</p>}
+      {finished && <p className="status">Tebrikler!</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow choosing between Lock Game and new Sudoku game
- restart button now returns to home screen
- center the app and enlarge fonts on desktop
- add spinning effect with perspective
- implement Sudoku with three difficulty levels
- document Sudoku in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688672f37bc48327aa2f1cfc5fe8ce78