### PR TITLE
Improve dark mode styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,3 +110,16 @@
     width: 2rem;
   }
 }
+
+@media (min-width: 1024px) {
+  .digit-display {
+    font-size: 4rem;
+  }
+  .digit {
+    font-size: 3rem;
+    width: 3rem;
+  }
+  .wheel button {
+    width: 3rem;
+  }
+}

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -32,3 +32,17 @@
   margin-top: 0.5rem;
   font-weight: bold;
 }
+
+@media (prefers-color-scheme: dark) {
+  .board td {
+    border-color: #555;
+  }
+  .board input {
+    background: #222;
+    color: #eee;
+  }
+  .prefilled {
+    background: #444;
+    color: #fff;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,8 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #f0f0f0;
+  background-color: #121212;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -43,7 +43,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #333;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -70,6 +70,6 @@ button:focus-visible {
 
 @media (min-width: 1024px) {
   body {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- enhance readability in dark mode
- enlarge digit controls on desktop

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886787eb3308327bec2febb258a5615