### PR TITLE
Fix Sudoku pad input and colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -37,6 +37,10 @@
   color: inherit;
   outline: none;
 }
+.board input:disabled {
+  color: inherit;
+  -webkit-text-fill-color: inherit;
+}
 .prefilled {
   font-weight: bold;
 }
@@ -91,12 +95,19 @@
   display: flex;
   justify-content: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
   padding: 0.5rem;
   z-index: 500;
 }
 .digit-pad button {
   width: 2.5rem;
   height: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .digit-pad {
+    display: none;
+  }
 }
 .controls {
   margin-top: 0.5rem;
@@ -159,7 +170,7 @@
 .block4,
 .block6,
 .block8 {
-  background: #ffd700;
+  background: #fdb912;
   color: #000;
 }
 
@@ -167,7 +178,7 @@
 .block3,
 .block5,
 .block7 {
-  background: #a32638;
+  background: #a90432;
   color: #fff;
 }
 

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -170,6 +170,9 @@ export default function SudokuGame({ difficulty, onBack, version }) {
     const [r, c] = empties[Math.floor(Math.random() * empties.length)]
     const newBoard = board.map(row => [...row])
     newBoard[r][c] = rand.solution[r][c]
+    const newPuzzle = rand.puzzle.map(row => [...row])
+    newPuzzle[r][c] = rand.solution[r][c]
+    setRand({ ...rand, puzzle: newPuzzle })
     const newNotes = notes.map(row => row.map(n => [...n]))
     newNotes[r][c] = []
     setNotes(newNotes)
@@ -189,6 +192,9 @@ export default function SudokuGame({ difficulty, onBack, version }) {
     const [r, c] = empties[Math.floor(Math.random() * empties.length)]
     const newBoard = board.map(row => [...row])
     newBoard[r][c] = rand.solution[r][c]
+    const newPuzzle = rand.puzzle.map(row => [...row])
+    newPuzzle[r][c] = rand.solution[r][c]
+    setRand({ ...rand, puzzle: newPuzzle })
     const newNotes = notes.map(row => row.map(n => [...n]))
     newNotes[r][c] = []
     setNotes(newNotes)
@@ -265,37 +271,38 @@ export default function SudokuGame({ difficulty, onBack, version }) {
                     key={c}
                     className={`${rand.puzzle[r][c] !== 0 ? 'prefilled ' : ''}${block}${activeCell && activeCell.r === r && activeCell.c === c ? ' active-cell' : ''}`.trim()}
                   >
-                    {rand.puzzle[r][c] !== 0 ? (
-                      rand.puzzle[r][c]
-                    ) : (
-                      <>
-                          <input
-                            value={cell === 0 ? '' : cell}
-                          readOnly
-                          onFocus={() => setActiveCell({ r, c })}
-                          onBlur={() => setActiveCell(null)}
-                          onKeyDown={e => {
-                            const n = parseInt(e.key, 10)
-                            if (!isNaN(n)) {
-                              handleChange(r, c, n)
-                            } else if (e.key === 'Backspace' || e.key === 'Delete') {
-                              handleChange(r, c, '')
-                            }
-                          }}
-                          />
-                        {notes[r][c].length > 0 && (
-                          <div className="note-cell readonly">
-                            {Array.from({ length: cfg.size }, (_, i) => i + 1).map(n => (
-                              <span
-                                key={n}
-                                className={notes[r][c].includes(n) ? 'active' : ''}
-                              >
-                                {n}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-                      </>
+                    <input
+                      value={cell === 0 ? '' : cell}
+                      readOnly
+                      disabled={rand.puzzle[r][c] !== 0}
+                      inputMode="none"
+                      onFocus={() => setActiveCell({ r, c })}
+                      onBlur={e => {
+                        const next = e.relatedTarget
+                        if (!next || !next.closest('.digit-pad')) {
+                          setActiveCell(null)
+                        }
+                      }}
+                      onKeyDown={e => {
+                        const n = parseInt(e.key, 10)
+                        if (!isNaN(n)) {
+                          handleChange(r, c, n)
+                        } else if (e.key === 'Backspace' || e.key === 'Delete') {
+                          handleChange(r, c, '')
+                        }
+                      }}
+                    />
+                    {notes[r][c].length > 0 && (
+                      <div className="note-cell readonly">
+                        {Array.from({ length: cfg.size }, (_, i) => i + 1).map(n => (
+                          <span
+                            key={n}
+                            className={notes[r][c].includes(n) ? 'active' : ''}
+                          >
+                            {n}
+                          </span>
+                        ))}
+                      </div>
                     )}
                   </td>
                 )


### PR DESCRIPTION
## Summary
- avoid mobile keyboard by using `inputMode="none"`
- update Galatasaray red/yellow colors
- bump version to 0.1.4

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68869441cc988327a2e3c052c1cebddf