### PR TITLE
Implement super mode and glass style

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Bu proje React ile geliştirilmiş iki farklı oyun içerir: sayısal kilit tahm
 
 Sudoku oyununda üç zorluk seviyesi bulunur. Kolay seviyede 5x5 karelik mini bir Sudoku sunulur ve üç ipucu verilir. Orta seviyede 9x9 standart Sudoku daha fazla açık sayıyla gelir ve yine üç ipucu sağlanır. Zor seviyede 9x9 Sudoku daha az açık sayı içerir, üç yanılma hakkı ve tek ipucu vardır.
 
+Beş kez oyun logosuna tıklanırsa **Süper Mod** aktif olur ve ipucu hakkı sınırsız hale gelir. Bu modda notları otomatik düzeltme düğmesi görünür.
+
 Her tahmin sonrası sonuçlar renklerle gösterilir:
 
 - **Yeşil:** Rakam doğru ve doğru sırada.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,7 @@
   justify-content: center;
   align-items: center;
   animation: fadein 0.5s ease-in;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.4);
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(10px);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -212,6 +212,7 @@ export default function App() {
       </div>
       {!finished && <button onClick={handleSubmit}>Tahmin Et</button>}
       {finished && <button onClick={handleRestart}>Yeniden Başlat</button>}
+      <button onClick={handleRestart}>Ana Sayfa</button>
       <p>Kalan Hak: {maxAttempts - attempts.length}</p>
       {status && <p className="status">{status}</p>}
       <div className="history">

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -14,6 +14,10 @@
 .board {
   border-collapse: collapse;
   margin: 0.5rem auto;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
 .board.size9 td:nth-child(3n) {
   border-right: 3px solid #333;
@@ -205,7 +209,7 @@
 .block4,
 .block6,
 .block8 {
-  background: #fdb912;
+  background: rgba(253, 185, 18, 0.3);
   color: #000;
 }
 
@@ -213,7 +217,7 @@
 .block3,
 .block5,
 .block7 {
-  background: #a90432;
+  background: rgba(169, 4, 50, 0.5);
   color: #fff;
 }
 

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -92,6 +92,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
   const [rand, setRand] = useState(() => createRandomData())
   const [board, setBoard] = useState(rand.puzzle.map(r => [...r]))
   const [hintsLeft, setHintsLeft] = useState(cfg.hints)
+  const [superMode, setSuperMode] = useState(false)
   const [mistakes, setMistakes] = useState(0)
   const [noteMode, setNoteMode] = useState(false)
   const [mouse, setMouse] = useState({ x: 0, y: 0 })
@@ -199,7 +200,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
   }
 
   const giveHint = () => {
-    if (hintsLeft <= 0 || finished) return
+    if ((!superMode && hintsLeft <= 0) || finished) return
     const empties = []
     for (let r = 0; r < cfg.size; r++) {
       for (let c = 0; c < cfg.size; c++) {
@@ -218,7 +219,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
     newNotes = removeNotesForNumber(r, c, rand.solution[r][c], newNotes)
     setNotes(newNotes)
     setBoard(newBoard)
-    setHintsLeft(hintsLeft - 1)
+    if (!superMode) setHintsLeft(hintsLeft - 1)
   }
 
   const giveFreeHint = () => {
@@ -269,18 +270,14 @@ export default function SudokuGame({ difficulty, onBack, version }) {
     setNotes(newNotes)
   }
 
-  const fixCurrentNote = () => {
-    if (!activeCell) return
-    const { r, c } = activeCell
-    const allowed = getAllowedDigits(r, c)
-    const newNotes = notes.map(row => row.map(n => [...n]))
-    newNotes[r][c] = allowed
-    setNotes(newNotes)
-  }
 
   const handleHeaderClick = () => {
     const count = headerClicks + 1
     if (count >= 5) {
+      if (!superMode) {
+        setSuperMode(true)
+        setHintsLeft(Infinity)
+      }
       giveFreeHint()
       setHeaderClicks(0)
     } else {
@@ -293,7 +290,7 @@ export default function SudokuGame({ difficulty, onBack, version }) {
     setRand(newData)
     setBoard(newData.puzzle.map(r => [...r]))
     setNotes(newData.puzzle.map(row => row.map(() => [])))
-    setHintsLeft(cfg.hints)
+    setHintsLeft(superMode ? Infinity : cfg.hints)
     setMistakes(0)
   }
 
@@ -387,10 +384,11 @@ export default function SudokuGame({ difficulty, onBack, version }) {
         >
           ✏️
         </button>
-        <button onClick={fixCurrentNote}>Notu Düzelt</button>
-        <button onClick={fixAllNotes}>Notları Düzelt</button>
-        <button onClick={giveHint} disabled={hintsLeft <= 0}>
-          Ipucu ({hintsLeft})
+        {superMode && (
+          <button onClick={fixAllNotes}>Notları Düzelt</button>
+        )}
+        <button onClick={giveHint} disabled={!superMode && hintsLeft <= 0}>
+          Ipucu ({superMode ? '∞' : hintsLeft})
         </button>
         <button onClick={onBack}>Ana Sayfa</button>
       </div>


### PR DESCRIPTION
## Summary
- enable hidden super mode after 5 logo clicks
- show unlimited hints and fix notes button only in super mode
- add glassy board styling with Galatasaray colors
- tweak app background and provide home button for lock game
- document super mode and bump version to 0.1.9

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887a5ad4dc48327a31add729556419f