### PR TITLE
Fix Sudoku note mode behavior

### DIFF
--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -117,6 +117,7 @@
 }
 .wrong input {
   color: #e53935;
+  -webkit-text-fill-color: #e53935;
 }
 .digit-pad {
   margin-top: 0.5rem;
@@ -201,24 +202,6 @@
   to { transform: scale(1); }
 }
 
-.note-mode {
-  cursor: none;
-}
-
-.pen-cursor {
-  position: fixed;
-  width: 24px;
-  height: 24px;
-  pointer-events: none;
-  z-index: 1000;
-  transform: translate(-50%, -50%);
-}
-
-.note-mode .pen-cursor {
-  border: 2px solid var(--secondary);
-  border-radius: 50%;
-  box-sizing: border-box;
-}
 
 @media (min-width: 1024px) {
   .board td {

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react'
-import pen from './assets/pen.svg'
+import { useState } from 'react'
 import './Sudoku.css'
 
 const data = {
@@ -95,7 +94,6 @@ export default function SudokuGame({ difficulty, onBack }) {
   const [superMode, setSuperMode] = useState(false)
   const [mistakes, setMistakes] = useState(0)
   const [noteMode, setNoteMode] = useState(false)
-  const [mouse, setMouse] = useState({ x: 0, y: 0 })
   const [notes, setNotes] = useState(
     rand.puzzle.map(row => row.map(() => []))
   )
@@ -107,12 +105,7 @@ export default function SudokuGame({ difficulty, onBack }) {
     row.every((val, c) => val === rand.solution[r][c])
   )
 
-  useEffect(() => {
-    if (!noteMode) return
-    const move = e => setMouse({ x: e.clientX, y: e.clientY })
-    window.addEventListener('mousemove', move)
-    return () => window.removeEventListener('mousemove', move)
-  }, [noteMode])
+
 
   const toggleNote = (r, c, num) => {
     const newNotes = notes.map(row => row.map(n => [...n]))
@@ -180,10 +173,14 @@ export default function SudokuGame({ difficulty, onBack }) {
         delete e[`${r}-${c}`]
         return e
       })
+      focusNextCell(r, c, newBoard)
       return
     }
     const num = parseInt(val, 10)
-    if (!num || num < 1 || num > cfg.size) return
+    if (!num || num < 1 || num > cfg.size) {
+      focusNextCell(r, c, board)
+      return
+    }
     const newBoard = board.map(row => [...row])
     newBoard[r][c] = num
     setErrors(prev => {
@@ -321,7 +318,7 @@ export default function SudokuGame({ difficulty, onBack }) {
   }
 
   return (
-    <div className={`sudoku${noteMode ? ' note-mode' : ''}${finished ? ' finished' : ''}`}>
+    <div className={`sudoku${finished ? ' finished' : ''}`}>
       <h1 onClick={handleHeaderClick}>Sudoku</h1>
       {difficulty === 'hard' && (
         <p className="mistakes">Hata: {mistakes}/{maxMistakes}</p>
@@ -435,14 +432,7 @@ export default function SudokuGame({ difficulty, onBack }) {
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
-      {noteMode && (
-        <img
-          src={pen}
-          alt="pen"
-          className="pen-cursor"
-          style={{ left: mouse.x, top: mouse.y }}
-        />
-      )}
+
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- highlight wrong entries reliably
- move to the next cell on every key entry
- drop custom pen cursor overlay

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887bd830bdc83278996878010626828