### PR TITLE
Add Sudoku timer and improve notes

### DIFF
--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -7,8 +7,21 @@
   margin: 0.1rem 0;
   font-size: 1.4rem;
 }
-.mistakes {
+.info-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.info-bar span {
+  flex: 1;
+}
+.info-bar .errors {
+  text-align: left;
+}
+.info-bar .best {
+  text-align: right;
 }
 
 .board {
@@ -99,13 +112,17 @@
   border-radius: 8px;
   color: var(--secondary);
 }
+.note-btn:hover {
+  border: none;
+}
 .note-btn.active {
   background: var(--primary);
   color: #fff;
-  border: 1px solid var(--secondary);
+  border: none;
 }
 .note-btn.inactive {
   opacity: 0.6;
+  background: transparent;
 }
 
 .hint-count {


### PR DESCRIPTION
## Summary
- add timer and best time tracking for Sudoku
- enhance note mode styles and keep focus on wrong entry
- show info bar with mistakes, timer and best time

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887c14a898883279494fd55bf5fb6d6