### PR TITLE
Add Kakuro puzzle and lock game improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # minigames
 
-Bu proje React ile geliştirilmiş iki farklı oyun içerir: sayısal kilit tahmini ve Sudoku. Kilit oyununda sistem rastgele hanelerden oluşan bir şifre belirler. Oyuncu rakamları yukarı/aşağı okları ile değiştirerek tahmin yapar. Toplam deneme hakkı seçilen zorluğa göre değişir.
+Bu proje React ile geliştirilmiş bir mini oyun setidir. Sayısal kilit, Sudoku ve basit bir Kakuro bulmacası içerir. Kilit oyununda sistem rastgele hanelerden oluşan bir şifre belirler. Oyuncu rakamları yukarı/aşağı okları ile değiştirerek tahmin yapar. Toplam deneme hakkı seçilen zorluğa göre değişir. Kolay ve orta zorlukta birer ipucu kullanılabilir ve oyun her yenilendiğinde tema rastgele seçilir.
+Her oyunda başlık yanında bir **bilgi** simgesi bulunur. Bu simge üzerine gelindiğinde oyunun kuralları kısaca görüntülenir. Yanındaki **Devamı** düğmesi ise alfabetik sırayla listelenmiş küçük ipuçlarını açar.
 
 Sudoku oyununda üç zorluk seviyesi bulunur. Kolay seviyede 5x5 karelik mini bir Sudoku sunulur ve üç ipucu verilir. Orta seviyede 9x9 standart Sudoku daha fazla açık sayıyla gelir ve yine üç ipucu sağlanır. Zor seviyede 9x9 Sudoku daha az açık sayı içerir, üç yanılma hakkı ve tek ipucu vardır.
 
@@ -13,6 +14,8 @@ Her tahmin sonrası sonuçlar renklerle gösterilir:
 - **Kırmızı:** Rakam şifre içinde bulunmuyor.
 
 Tüm rakamlar doğru tahmin edildiğinde veya haklar bittiğinde oyun sona erer ve yeniden başlatma butonu görünür.
+
+Kakuro oyununda ise satır ve sütunlardaki toplamları kullanarak boş kareleri doğru sayılarla doldurmaya çalışırsınız.
 
 ## Kurulum
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import SudokuGame from './SudokuGame.jsx'
 import KakuroGame from './KakuroGame.jsx'
 import TabooGame from './TabooGame.jsx'
 import WordPuzzleGame from './WordPuzzleGame.jsx'
+import Tooltip from './Tooltip.jsx'
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
 }
@@ -34,6 +35,21 @@ export default function App() {
   const [mode, setMode] = useState('easy') // 'easy' or 'challenge'
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
   const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
+  const themes = [
+    'glass',
+    'broken',
+    'fabric',
+    'lime',
+    'forest',
+    'pastel',
+    'watercolor',
+    'ocean',
+    'metal',
+    'wood',
+    'earth',
+  ]
+  const randomTheme = () => themes[Math.floor(Math.random() * themes.length)]
+
   const [theme, setTheme] = useState('glass')
   const [palette, setPalette] = useState('gs')
 
@@ -44,6 +60,13 @@ export default function App() {
   const [attempts, setAttempts] = useState([])
   const [status, setStatus] = useState('')
   const [bestScore, setBestScore] = useState(null)
+  const [hintsLeft, setHintsLeft] = useState(0)
+  const [revealed, setRevealed] = useState([])
+  const lockTricks = [
+    'Ayni rakamdan birden fazla kullanabilirsiniz',
+    'Ilk tahminlerde rastgele deneyin',
+    'Sonuclara gore rakamlari yer degistirin',
+  ].sort()
 
   useEffect(() => {
     document.body.className = `theme-${theme} palette-${palette}`
@@ -64,12 +87,15 @@ export default function App() {
       const attemptsMap = { easy: 10, medium: 8, hard: 6 }
       const len = lengths[difficulty]
       const att = attemptsMap[difficulty]
+      setTheme(randomTheme())
       setCodeLength(len)
       setMaxAttempts(att)
       setSecret(generateSecret(len))
       setGuess(Array(len).fill(0))
       setAttempts([])
       setStatus('')
+      setHintsLeft(difficulty === 'hard' ? 0 : 1)
+      setRevealed(Array(len).fill(false))
       setScreen('play')
     } else {
       if (gameType === 'sudoku') setScreen('sudoku')
@@ -164,6 +190,38 @@ export default function App() {
         setStatus('Deneme hakkınız bitti. Şifre: ' + secret.join(''))
       }
     }
+  }
+
+  const restartLockGame = () => {
+    const lengths = { easy: 4, medium: 5, hard: 6 }
+    const attemptsMap = { easy: 10, medium: 8, hard: 6 }
+    const len = lengths[difficulty]
+    const att = attemptsMap[difficulty]
+    setTheme(randomTheme())
+    setCodeLength(len)
+    setMaxAttempts(att)
+    setSecret(generateSecret(len))
+    setGuess(Array(len).fill(0))
+    setAttempts([])
+    setStatus('')
+    setHintsLeft(difficulty === 'hard' ? 0 : 1)
+    setRevealed(Array(len).fill(false))
+  }
+
+  const useHint = () => {
+    if (hintsLeft <= 0) return
+    const choices = revealed
+      .map((r, i) => (!r ? i : null))
+      .filter(i => i !== null)
+    if (choices.length === 0) return
+    const idx = choices[Math.floor(Math.random() * choices.length)]
+    const g = [...guess]
+    g[idx] = secret[idx]
+    setGuess(g)
+    const rev = [...revealed]
+    rev[idx] = true
+    setRevealed(rev)
+    setHintsLeft(hintsLeft - 1)
   }
 
   const handleRestart = () => {
@@ -280,20 +338,41 @@ export default function App() {
 
     return (
       <div className="app">
-        <h1 className="lock-title">{mode === 'easy' ? 'LockGame Casual' : 'Lock Game Challenge'}</h1>
+        <h1 className="lock-title">
+          {mode === 'easy' ? 'LockGame Casual' : 'Lock Game Challenge'}
+          <Tooltip content="Rakamlari oklarla degistirip dogru sifreyi bulmaya calisin.">
+            <span> ℹ️</span>
+          </Tooltip>
+          <Tooltip
+            content={(
+              <select>
+                {lockTricks.map((t, i) => (
+                  <option key={i}>{t}</option>
+                ))}
+              </select>
+            )}
+          >
+            <button className="icon-btn">Devamı</button>
+          </Tooltip>
+        </h1>
         <div className="wheels">
         {guess.map((d, i) => (
           <DigitWheel
             key={i}
             value={d}
             onChange={(val) => handleChange(i, val)}
-            disabled={finished}
+            disabled={finished || revealed[i]}
           />
         ))}
       </div>
       <div className="lock-controls">
         {!finished && <button onClick={handleSubmit}>Tahmin Et</button>}
-        {finished && <button className="icon-btn" onClick={handleRestart}>🔄</button>}
+        {!finished && hintsLeft > 0 && (
+          <button className="icon-btn" onClick={useHint}>💡 ({hintsLeft})</button>
+        )}
+        {finished && (
+          <button className="icon-btn" onClick={restartLockGame}>🔄</button>
+        )}
         <button className="icon-btn" onClick={handleRestart}>🏠</button>
       </div>
       <p>Kalan Hak: {maxAttempts - attempts.length}</p>

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -2,3 +2,25 @@
   text-align: center;
   animation: fadein 0.5s ease-in;
 }
+
+.kakuro-board {
+  margin: 0 auto;
+  border-collapse: collapse;
+}
+
+.kakuro-board th,
+.kakuro-board td {
+  border: 1px solid #ccc;
+  width: 2rem;
+  height: 2rem;
+  text-align: center;
+}
+
+.kakuro-board input {
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+}

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -1,12 +1,89 @@
-import React from 'react'
+import { useState } from 'react'
 import './Kakuro.css'
+import Tooltip from './Tooltip.jsx'
 
 export default function KakuroGame({ onBack }) {
+  const tricks = [
+    'Ayni satirda tekrar etmeyin',
+    'Kombinasyonlari ogrenin',
+    'Min ve max degerleri hesaplayin',
+  ].sort()
+  const size = 3
+  const rowSums = [6, 15, 24]
+  const colSums = [12, 15, 18]
+  const solution = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ]
+  const emptyBoard = () => Array.from({ length: size }, () => Array(size).fill(''))
+  const [board, setBoard] = useState(emptyBoard())
+
+  const finished = board.every((row, r) =>
+    row.every((v, c) => parseInt(v, 10) === solution[r][c])
+  )
+
+  const handleChange = (r, c, val) => {
+    if (finished) return
+    const n = val.replace(/\D/g, '')
+    const next = board.map(row => [...row])
+    next[r][c] = n
+    setBoard(next)
+  }
+
+  const restartGame = () => {
+    setBoard(emptyBoard())
+  }
+
   return (
     <div className="kakuro">
-      <h1>Kakuro</h1>
-      <p>Yeni oyun yakında burada!</p>
-      <button className="icon-btn" onClick={onBack}>🏠</button>
+      <h1>
+        Kakuro
+        <Tooltip content="Satir ve sutun toplamina gore kareleri doldurun.">
+          <span> ℹ️</span>
+        </Tooltip>
+        <Tooltip
+          content={(
+            <select>
+              {tricks.map((t, i) => (
+                <option key={i}>{t}</option>
+              ))}
+            </select>
+          )}
+        >
+          <button className="icon-btn">Devamı</button>
+        </Tooltip>
+      </h1>
+      <table className="kakuro-board">
+        <thead>
+          <tr>
+            <th />
+            {colSums.map((s, i) => (
+              <th key={i}>{s}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {board.map((row, r) => (
+            <tr key={r}>
+              <th>{rowSums[r]}</th>
+              {row.map((val, c) => (
+                <td key={c}>
+                  <input
+                    value={val}
+                    onChange={e => handleChange(r, c, e.target.value)}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {finished && <p className="status">Tebrikler!</p>}
+      <div className="end-controls">
+        <button className="icon-btn" onClick={restartGame}>🔄</button>
+        <button className="icon-btn" onClick={onBack}>🏠</button>
+      </div>
     </div>
   )
 }

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import './Sudoku.css'
+import Tooltip from './Tooltip.jsx'
 
 const data = {
   easy: {
@@ -75,6 +76,11 @@ const data = {
 }
 
 export default function SudokuGame({ difficulty, onBack }) {
+  const tricks = [
+    'Bos hucrelerde olasi rakamlari not alin',
+    'Satir ve sutunlari tarayarak eksik rakamlari bulun',
+    'Tek ihtimali olan hucrelere odaklanin',
+  ].sort()
   const cfg = data[difficulty]
   const createRandomData = () => {
     const digits = Array.from({ length: cfg.size }, (_, i) => i + 1)
@@ -357,7 +363,23 @@ export default function SudokuGame({ difficulty, onBack }) {
 
   return (
     <div className={`sudoku${finished ? ' finished' : ''}`}>
-      <h1 onClick={handleHeaderClick}>Sudoku</h1>
+      <h1 onClick={handleHeaderClick}>
+        Sudoku
+        <Tooltip content="Her satir, sutun ve blokta 1-9 arasi rakamlar tekrarsiz olmali.">
+          <span> ℹ️</span>
+        </Tooltip>
+        <Tooltip
+          content={(
+            <select>
+              {tricks.map((t, i) => (
+                <option key={i}>{t}</option>
+              ))}
+            </select>
+          )}
+        >
+          <button className="icon-btn">Devamı</button>
+        </Tooltip>
+      </h1>
       <div className="info-bar">
         <span className="errors">Hata: {mistakes}{
           difficulty === 'hard' ? `/${maxMistakes}` : ''

--- a/src/TabooGame.jsx
+++ b/src/TabooGame.jsx
@@ -1,10 +1,32 @@
 import React from 'react'
 import './Taboo.css'
+import Tooltip from './Tooltip.jsx'
 
 export default function TabooGame({ onBack }) {
+  const tricks = [
+    'Benzer kelimelerden kacinin',
+    'Jest ve mimikleri kullanin',
+    'Zamani iyi yonetin',
+  ].sort()
   return (
     <div className="taboo">
-      <h1>Tabu</h1>
+      <h1>
+        Tabu
+        <Tooltip content="Yasakli kelimeleri soylemeden ana kelimeyi takiminiza anlatin.">
+          <span> ℹ️</span>
+        </Tooltip>
+        <Tooltip
+          content={(
+            <select>
+              {tricks.map((t, i) => (
+                <option key={i}>{t}</option>
+              ))}
+            </select>
+          )}
+        >
+          <button className="icon-btn">Devamı</button>
+        </Tooltip>
+      </h1>
       <p>Yeni oyun yakında burada!</p>
       <button className="icon-btn" onClick={onBack}>🏠</button>
     </div>

--- a/src/Tooltip.css
+++ b/src/Tooltip.css
@@ -1,0 +1,25 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+.tooltip-text {
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  text-align: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 10;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: opacity 0.3s;
+  white-space: pre-line;
+}
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import './Tooltip.css'
+
+export default function Tooltip({ content, children }) {
+  return (
+    <span className="tooltip">
+      {children}
+      <span className="tooltip-text">{content}</span>
+    </span>
+  )
+}

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -1,10 +1,32 @@
 import React from 'react'
 import './WordPuzzle.css'
+import Tooltip from './Tooltip.jsx'
 
 export default function WordPuzzleGame({ onBack }) {
+  const tricks = [
+    'Harf dagilimini inceleyin',
+    'Kelimeleri capraz kontrol edin',
+    'Kisa kelimelerle baslayin',
+  ].sort()
   return (
     <div className="word-puzzle">
-      <h1>Kelime Bulmaca</h1>
+      <h1>
+        Kelime Bulmaca
+        <Tooltip content="Hafleri kullanarak anlamli kelimeler olusturun.">
+          <span> ℹ️</span>
+        </Tooltip>
+        <Tooltip
+          content={(
+            <select>
+              {tricks.map((t, i) => (
+                <option key={i}>{t}</option>
+              ))}
+            </select>
+          )}
+        >
+          <button className="icon-btn">Devamı</button>
+        </Tooltip>
+      </h1>
       <p>Yeni oyun yakında burada!</p>
       <button className="icon-btn" onClick={onBack}>🏠</button>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -144,15 +144,15 @@ button {
 }
 
 .icon-btn {
-  padding: 0.4em;
+  padding: 0.4em 0.6em;
   font-size: 1.4rem;
   background-color: var(--primary);
   border: none;
   color: #fff;
   border-radius: 8px;
-  width: 2.2rem;
+  min-width: 2.2rem;
   height: 2.2rem;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
 }
@@ -200,4 +200,29 @@ button:focus-visible {
   body {
     font-size: 1.5rem;
   }
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+.tooltip-text {
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  text-align: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 10;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: opacity 0.3s;
+  white-space: pre-line;
+}
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- implement simple Kakuro puzzle
- add hint support for the lock game on easy and medium
- restart button now restarts lock game with same settings
- randomize theme each time lock game starts or restarts
- bump version to 0.4.0
- update README
- add info tooltips with tricks dropdowns on every game
- fix hint button size so icon text fits

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887dd8a2e4483279b28fa4af3c3c4d0