### PR TITLE
Add word puzzle and harder Kakuro

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.3.1</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.5.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,20 +35,22 @@ export default function App() {
   const [mode, setMode] = useState('easy') // 'easy' or 'challenge'
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
   const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
-  const themes = [
-    'broken',
-    'earth',
-    'fabric',
-    'forest',
-    'glass',
-    'lime',
-    'metal',
-    'ocean',
-    'pastel',
-    'watercolor',
-    'wood',
-  ]
-  const randomTheme = () => themes[Math.floor(Math.random() * themes.length)]
+  const [kakuroDifficulty, setKakuroDifficulty] = useState('easy')
+  const themeOptions = [
+    { value: 'broken', label: 'Kırık Cam' },
+    { value: 'earth', label: 'Toprak' },
+    { value: 'fabric', label: 'Kumaş' },
+    { value: 'forest', label: 'Orman' },
+    { value: 'glass', label: 'Bulanık Cam' },
+    { value: 'lime', label: 'Kireç' },
+    { value: 'metal', label: 'Metal' },
+    { value: 'ocean', label: 'Okyanus' },
+    { value: 'pastel', label: 'Pastel' },
+    { value: 'watercolor', label: 'Sulu Boya' },
+    { value: 'wood', label: 'Ahşap' },
+  ].sort((a, b) => a.label.localeCompare(b.label, 'tr'))
+  const randomTheme = () =>
+    themeOptions[Math.floor(Math.random() * themeOptions.length)].value
 
   const [theme, setTheme] = useState(randomTheme())
   const [palette, setPalette] = useState('gs')
@@ -272,20 +274,22 @@ export default function App() {
               </select>
             </div>
           )}
+          {gameType === 'kakuro' && (
+            <div>
+              <label>Zorluk: </label>
+              <select value={kakuroDifficulty} onChange={(e) => setKakuroDifficulty(e.target.value)}>
+                <option value="easy">3x3 Kolay</option>
+                <option value="medium">4x4 Orta</option>
+                <option value="hard">5x5 Zor</option>
+              </select>
+            </div>
+          )}
           <div>
             <label>Tema: </label>
             <select value={theme} onChange={(e) => setTheme(e.target.value)}>
-              <option value="broken">Kırık Cam</option>
-              <option value="earth">Toprak</option>
-              <option value="fabric">Kumaş</option>
-              <option value="forest">Orman</option>
-              <option value="glass">Bulanık Cam</option>
-              <option value="lime">Kireç</option>
-              <option value="metal">Metal</option>
-              <option value="ocean">Okyanus</option>
-              <option value="pastel">Pastel</option>
-              <option value="watercolor">Sulu Boya</option>
-              <option value="wood">Ahşap</option>
+              {themeOptions.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
             </select>
           </div>
           <div>
@@ -315,7 +319,7 @@ export default function App() {
   if (screen === 'kakuro') {
     return (
       <div className="app kakuro-app">
-        <KakuroGame onBack={handleRestart} />
+        <KakuroGame difficulty={kakuroDifficulty} onBack={handleRestart} />
       </div>
     )
   }

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -24,3 +24,37 @@
   border: none;
   color: inherit;
 }
+
+.block-cell {
+  background: #333;
+}
+
+.info-bar {
+  display: flex;
+  justify-content: space-between;
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.info-bar .best {
+  text-align: right;
+  flex: 1;
+}
+
+.controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.end-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.status {
+  margin-top: 0.5rem;
+  font-weight: bold;
+}

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -1,38 +1,165 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './Kakuro.css'
 import Tooltip from './Tooltip.jsx'
 
-export default function KakuroGame({ onBack }) {
+export default function KakuroGame({ difficulty, onBack }) {
   const tricks = [
     'Ayni satirda tekrar etmeyin',
     'Kombinasyonlari ogrenin',
     'Min ve max degerleri hesaplayin',
   ].sort()
-  const size = 3
-  const rowSums = [6, 15, 24]
-  const colSums = [12, 15, 18]
-  const solution = [
-    [1, 2, 3],
-    [4, 5, 6],
-    [7, 8, 9],
-  ]
-  const emptyBoard = () => Array.from({ length: size }, () => Array(size).fill(''))
+
+  const data = {
+    easy: {
+      size: 3,
+      hints: 3,
+      blocked: [[1, 1]],
+      prefilled: [[0, 0], [2, 2]],
+      solution: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    },
+    medium: {
+      size: 4,
+      hints: 3,
+      blocked: [[1, 1], [2, 2]],
+      prefilled: [[0, 0], [3, 3]],
+      solution: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 1, 2, 3],
+        [4, 5, 6, 7],
+      ],
+    },
+    hard: {
+      size: 5,
+      hints: 1,
+      blocked: [
+        [1, 1],
+        [2, 3],
+        [3, 2],
+      ],
+      prefilled: [[0, 0]],
+      solution: [
+        [1, 2, 3, 4, 5],
+        [6, 7, 8, 9, 1],
+        [2, 3, 4, 5, 6],
+        [7, 8, 9, 1, 2],
+        [3, 4, 5, 6, 7],
+      ],
+    },
+  }
+
+  const cfg = data[difficulty]
+  const blockSet = new Set(cfg.blocked.map(([r, c]) => `${r}-${c}`))
+  const prefillSet = new Set(cfg.prefilled.map(([r, c]) => `${r}-${c}`))
+
+  const computeSums = (sol) => {
+    const row = sol.map((row, r) =>
+      row.reduce((acc, val, c) =>
+        blockSet.has(`${r}-${c}`) ? acc : acc + val, 0)
+    )
+    const col = []
+    for (let c = 0; c < cfg.size; c++) {
+      let s = 0
+      for (let r = 0; r < cfg.size; r++) {
+        if (!blockSet.has(`${r}-${c}`)) s += sol[r][c]
+      }
+      col.push(s)
+    }
+    return { row, col }
+  }
+
+  const { row: rowSums, col: colSums } = computeSums(cfg.solution)
+
+  const emptyBoard = () =>
+    cfg.solution.map((row, r) =>
+      row.map((val, c) => {
+        const pos = `${r}-${c}`
+        if (blockSet.has(pos)) return null
+        if (prefillSet.has(pos)) return val.toString()
+        return ''
+      })
+    )
+
   const [board, setBoard] = useState(emptyBoard())
+  const [hintsLeft, setHintsLeft] = useState(cfg.hints)
+  const [startTime, setStartTime] = useState(Date.now())
+  const [elapsed, setElapsed] = useState(0)
+  const [bestTime, setBestTime] = useState(() => {
+    const s = localStorage.getItem(`kakuroBest-${difficulty}`)
+    return s ? parseInt(s, 10) : null
+  })
 
   const finished = board.every((row, r) =>
-    row.every((v, c) => parseInt(v, 10) === solution[r][c])
+    row.every((v, c) =>
+      blockSet.has(`${r}-${c}`) || parseInt(v, 10) === cfg.solution[r][c]
+    )
   )
 
   const handleChange = (r, c, val) => {
     if (finished) return
+    if (blockSet.has(`${r}-${c}`) || prefillSet.has(`${r}-${c}`)) return
     const n = val.replace(/\D/g, '')
     const next = board.map(row => [...row])
     next[r][c] = n
     setBoard(next)
   }
 
+  useEffect(() => {
+    if (finished) return
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startTime) / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [startTime, finished])
+
+  useEffect(() => {
+    if (finished) {
+      const total = Math.floor((Date.now() - startTime) / 1000)
+      setElapsed(total)
+      if (bestTime === null || total < bestTime) {
+        setBestTime(total)
+        localStorage.setItem(`kakuroBest-${difficulty}`, total.toString())
+      }
+    }
+  }, [finished, bestTime, difficulty, startTime])
+
+  const giveHint = () => {
+    if (hintsLeft <= 0 || finished) return
+    const cells = []
+    for (let r = 0; r < cfg.size; r++) {
+      for (let c = 0; c < cfg.size; c++) {
+        const pos = `${r}-${c}`
+        if (!blockSet.has(pos) && !prefillSet.has(pos) && board[r][c] === '') {
+          cells.push([r, c])
+        }
+      }
+    }
+    if (cells.length === 0) return
+    const [r, c] = cells[Math.floor(Math.random() * cells.length)]
+    const next = board.map(row => [...row])
+    next[r][c] = cfg.solution[r][c].toString()
+    prefillSet.add(`${r}-${c}`)
+    setBoard(next)
+    setHintsLeft(hintsLeft - 1)
+  }
+
   const restartGame = () => {
     setBoard(emptyBoard())
+    setHintsLeft(cfg.hints)
+    setStartTime(Date.now())
+    setElapsed(0)
+  }
+
+  const formatTime = (s) => {
+    const m = Math.floor(s / 60)
+      .toString()
+      .padStart(2, '0')
+    const sec = (s % 60).toString().padStart(2, '0')
+    return `${m}:${sec}`
   }
 
   return (
@@ -41,6 +168,12 @@ export default function KakuroGame({ onBack }) {
         Kakuro
         <Tooltip info="Satir ve sutun toplamina gore kareleri doldurun." tips={tricks} />
       </h1>
+      <div className="info-bar">
+        <span>{formatTime(elapsed)}</span>
+        <span className="best">
+          {bestTime !== null ? formatTime(bestTime) : '--:--'}
+        </span>
+      </div>
       <table className="kakuro-board">
         <thead>
           <tr>
@@ -54,23 +187,45 @@ export default function KakuroGame({ onBack }) {
           {board.map((row, r) => (
             <tr key={r}>
               <th>{rowSums[r]}</th>
-              {row.map((val, c) => (
-                <td key={c}>
-                  <input
-                    value={val}
-                    onChange={e => handleChange(r, c, e.target.value)}
-                  />
-                </td>
-              ))}
+              {row.map((val, c) => {
+                const pos = `${r}-${c}`
+                if (blockSet.has(pos)) {
+                  return <td key={c} className="block-cell" />
+                }
+                const pre = prefillSet.has(pos)
+                return (
+                  <td key={c}>
+                    <input
+                      value={val}
+                      disabled={pre}
+                      onChange={e => handleChange(r, c, e.target.value)}
+                    />
+                  </td>
+                )
+              })}
             </tr>
           ))}
         </tbody>
       </table>
+      {!finished && (
+        <div className="controls">
+          <button
+            className="icon-btn"
+            onClick={giveHint}
+            disabled={hintsLeft <= 0}
+          >
+            💡 ({hintsLeft})
+          </button>
+          <button className="icon-btn" onClick={onBack}>🏠</button>
+        </div>
+      )}
       {finished && <p className="status">Tebrikler!</p>}
-      <div className="end-controls">
-        <button className="icon-btn" onClick={restartGame}>🔄</button>
-        <button className="icon-btn" onClick={onBack}>🏠</button>
-      </div>
+      {finished && (
+        <div className="end-controls">
+          <button className="icon-btn" onClick={restartGame}>🔄</button>
+          <button className="icon-btn" onClick={onBack}>🏠</button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -2,3 +2,34 @@
   text-align: center;
   animation: fadein 0.5s ease-in;
 }
+
+.controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.letter {
+  font-size: 1.5rem;
+  width: 1.5rem;
+  text-align: center;
+  padding: 0.25rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.letter.green {
+  background: #2ecc71;
+  color: #fff;
+}
+
+.letter.yellow {
+  background: #f1c40f;
+  color: #000;
+}
+
+.letter.gray {
+  background: #999;
+  color: #fff;
+}

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { useState } from 'react'
 import './WordPuzzle.css'
 import Tooltip from './Tooltip.jsx'
 
@@ -8,14 +8,148 @@ export default function WordPuzzleGame({ onBack }) {
     'Kelimeleri capraz kontrol edin',
     'Kisa kelimelerle baslayin',
   ].sort()
+
+  const words = [
+    'akide',
+    'bilet',
+    'cihan',
+    'defne',
+    'erdem',
+    'fidan',
+    'gizem',
+    'hayal',
+    'islem',
+    'kuzey',
+    'lamba',
+    'mutlu',
+    'nehir',
+    'orman',
+    'petek',
+    'radyo',
+    'sakin',
+    'tatil',
+    'vagon',
+    'yolcu',
+  ]
+
+  const randomWord = () => words[Math.floor(Math.random() * words.length)]
+
+  const [secret, setSecret] = useState(randomWord)
+  const [guess, setGuess] = useState('')
+  const [attempts, setAttempts] = useState([])
+  const [hintsLeft, setHintsLeft] = useState(1)
+  const [status, setStatus] = useState('')
+  const [bestScore, setBestScore] = useState(() => {
+    const s = localStorage.getItem('wordBest')
+    return s ? parseInt(s, 10) : null
+  })
+  const wordLen = secret.length
+
+  const finished = status !== ''
+
+  const evaluateColors = (g) => {
+    const res = Array(wordLen).fill('gray')
+    const secretArr = secret.split('')
+    const copy = secretArr.slice()
+    for (let i = 0; i < wordLen; i++) {
+      if (g[i] === secretArr[i]) {
+        res[i] = 'green'
+        copy[i] = null
+      }
+    }
+    for (let i = 0; i < wordLen; i++) {
+      if (res[i] === 'green') continue
+      const idx = copy.indexOf(g[i])
+      if (idx !== -1) {
+        res[i] = 'yellow'
+        copy[idx] = null
+      }
+    }
+    return res
+  }
+
+  const handleSubmit = () => {
+    if (finished || guess.length !== wordLen) return
+    const colors = evaluateColors(guess)
+    const newAttempts = [...attempts, { guess, colors }]
+    setAttempts(newAttempts)
+    if (guess === secret) {
+      setStatus('Tebrikler!')
+      if (bestScore === null || newAttempts.length < bestScore) {
+        setBestScore(newAttempts.length)
+        localStorage.setItem('wordBest', newAttempts.length.toString())
+      }
+    } else if (newAttempts.length >= 6) {
+      setStatus(`Kaybettiniz! Kelime ${secret}`)
+    }
+    setGuess('')
+  }
+
+  const giveHint = () => {
+    if (finished || hintsLeft <= 0) return
+    const unrevealed = []
+    for (let i = 0; i < wordLen; i++) {
+      if (!attempts.some(a => a.guess[i] === secret[i])) {
+        unrevealed.push(i)
+      }
+    }
+    if (unrevealed.length === 0) return
+    const idx = unrevealed[Math.floor(Math.random() * unrevealed.length)]
+    const arr = guess.padEnd(wordLen, ' ').split('')
+    arr[idx] = secret[idx]
+    setGuess(arr.join('').trimEnd())
+    setHintsLeft(hintsLeft - 1)
+  }
+
+  const restart = () => {
+    const w = randomWord()
+    setSecret(w)
+    setGuess('')
+    setAttempts([])
+    setHintsLeft(1)
+    setStatus('')
+  }
+
   return (
     <div className="word-puzzle">
       <h1>
         Kelime Bulmaca
-        <Tooltip info="Hafleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
+        <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>
-      <p>Yeni oyun yakında burada!</p>
-      <button className="icon-btn" onClick={onBack}>🏠</button>
+      <div className="controls">
+        {!finished && (
+          <>
+            <input
+              value={guess}
+              onChange={e => setGuess(e.target.value.toLowerCase())}
+              maxLength={wordLen}
+            />
+            <button onClick={handleSubmit}>Tahmin</button>
+            {hintsLeft > 0 && (
+              <button className="icon-btn" onClick={giveHint}>
+                💡 ({hintsLeft})
+              </button>
+            )}
+          </>
+        )}
+        {finished && (
+          <button className="icon-btn" onClick={restart}>
+            🔄
+          </button>
+        )}
+        <button className="icon-btn" onClick={onBack}>🏠</button>
+      </div>
+      {bestScore !== null && <p>Best Score: {bestScore}</p>}
+      {status && <p className="status">{status}</p>}
+      <div className="history">
+        {attempts.map((a, idx) => (
+          <div key={idx} className="attempt">
+            {a.guess.split('').map((ch, i) => (
+              <span key={i} className={`letter ${a.colors[i]}`}>{ch}</span>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement playable Word Puzzle game with best score and hint
- expand Kakuro with difficulty levels, hints and timing
- sort theme options alphabetically
- show Kakuro difficulty dropdown
- bump version to v0.5.0

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887e97510448327b49ebd220268d907