### PR TITLE
Add notes and random Kakuro puzzles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Her tahmin sonrası sonuçlar renklerle gösterilir:
 
 Tüm rakamlar doğru tahmin edildiğinde veya haklar bittiğinde oyun sona erer ve yeniden başlatma butonu görünür.
 
-Kakuro oyununda ise satır ve sütunlardaki toplamları kullanarak boş kareleri doğru sayılarla doldurmaya çalışırsınız.
+Kakuro oyununda ise satır ve sütunlardaki toplamları kullanarak boş kareleri doğru sayılarla doldurmaya çalışırsınız. Artık hücreler için küçük notlar bırakabilir ve yenileme düğmesine tıkladıkça rastgele sayılardan oluşan yeni bir tablo oluşturabilirsiniz.
 
 ## Kurulum
 

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -58,3 +58,54 @@
   margin-top: 0.5rem;
   font-weight: bold;
 }
+
+.note-cell {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  font-size: 0.7rem;
+}
+.note-cell span {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.2;
+}
+.note-cell.readonly span {
+  cursor: default;
+  opacity: 0.2;
+}
+.note-cell.readonly {
+  pointer-events: none;
+}
+.note-cell span.active {
+  color: #2196f3;
+  opacity: 1;
+}
+
+.note-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  padding: 0.4em;
+  border-radius: 8px;
+  color: var(--secondary);
+}
+.note-btn:hover {
+  border: none;
+}
+.note-btn.active {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+}
+.note-btn.inactive {
+  opacity: 0.6;
+  background: transparent;
+}


### PR DESCRIPTION
## Summary
- enable note taking in Kakuro similar to Sudoku
- create a new random mapping on every restart
- reset hint cells when restarting to avoid overflow
- document Kakuro updates in README
- remove `readOnly` from Kakuro inputs so phone keyboards open

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887eda50558832796ff4c7ad24cb259