### PR TITLE
Increase layout sizes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,28 +56,30 @@
 .options > div {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 1rem;
   justify-content: space-between;
   width: 100%;
 }
 
 .options select {
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.2rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   flex: 1;
+  font-size: 1.1rem;
 }
 .options button {
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.2rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   width: 100%;
+  font-size: 1.1rem;
 }
 
 @media (min-width: 1024px) {
   .options select,
   .options button {
-    font-size: 1.25rem;
+    font-size: 1.4rem;
   }
 }
 

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -17,8 +17,8 @@
 .kakuro-board th,
 .kakuro-board td {
   border: 1px solid #ccc;
-  width: 3.3rem;
-  height: 3.3rem;
+  width: 3.8rem;
+  height: 3.8rem;
   text-align: center;
   position: relative;
   color: #fff;
@@ -32,7 +32,7 @@
   text-align: center;
   background: transparent;
   border: none;
-  font-size: 1.5rem;
+  font-size: 1.75rem;
   color: #fff;
   text-shadow: 0 0 3px #000;
   outline: none;
@@ -168,21 +168,21 @@
 @media (max-width: 600px) {
   .kakuro-board th,
   .kakuro-board td {
-    width: 2.6rem;
-    height: 2.6rem;
+    width: 3rem;
+    height: 3rem;
   }
   .kakuro-board input {
-    font-size: 1.4rem;
+    font-size: 1.6rem;
   }
 }
 
 @media (min-width: 1024px) {
   .kakuro-board th,
   .kakuro-board td {
-    width: 4rem;
-    height: 4rem;
+    width: 4.5rem;
+    height: 4.5rem;
   }
   .kakuro-board input {
-    font-size: 2rem;
+    font-size: 2.2rem;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge selections in home screen
- make Kakuro board cells larger

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888c210dcd88327bd2777d92cd4e1d0