### PR TITLE
Enhance Tabu and word puzzle games

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.5.0</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.6.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -47,7 +47,7 @@
 .options {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   align-items: center;
   margin-bottom: 1rem;
   width: 100%;
@@ -56,7 +56,7 @@
 .options > div {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
   justify-content: space-between;
   width: 100%;
 }

--- a/src/Taboo.css
+++ b/src/Taboo.css
@@ -44,3 +44,11 @@
   background: rgba(0, 0, 0, 0.2);
   border-radius: 8px;
 }
+
+.menu-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}

--- a/src/TabooGame.jsx
+++ b/src/TabooGame.jsx
@@ -29,6 +29,16 @@ export default function TabooGame({ onBack }) {
     { word: 'televizyon', taboo: ['kumanda', 'ekran', 'kanal', 'haber', 'film'] },
     { word: 'kalabalik', taboo: ['insan', 'topluluk', 'ses', 'yogun', 'cadir'] },
     { word: 'futbol', taboo: ['top', 'gol', 'saha', 'hakem', 'takim'] },
+    { word: 'yazilim', taboo: ['kod', 'bilgisayar', 'program', 'yazmak', 'muhendis'] },
+    { word: 'market', taboo: ['alisveris', 'kasiyer', 'raf', 'sepet', 'magaza'] },
+    { word: 'egitim', taboo: ['okul', 'ogretmen', 'ders', 'ogrenci', 'sinav'] },
+    { word: 'tarih', taboo: ['gecmis', 'olay', 'kitap', 'muze', 'yil'] },
+    { word: 'saglik', taboo: ['doktor', 'hastane', 'ilac', 'hasta', 'tedavi'] },
+    { word: 'seyahat', taboo: ['gezi', 'yolculuk', 'tatil', 'otel', 'bavul'] },
+    { word: 'teknoloji', taboo: ['internet', 'cihaz', 'yeni', 'gelisim', 'akilli'] },
+    { word: 'arkadas', taboo: ['dost', 'sohbet', 'oyun', 'paylasim', 'yardim'] },
+    { word: 'sanat', taboo: ['resim', 'tiyatro', 'muzik', 'yaratici', 'sergi'] },
+    { word: 'macera', taboo: ['heyecan', 'seruven', 'film', 'risk', 'yeni'] },
   ]
 
   const [screen, setScreen] = useState('start')
@@ -122,8 +132,10 @@ export default function TabooGame({ onBack }) {
         <>
           <p className="score-board">Takim A: {scoreA} - Takim B: {scoreB}</p>
           <p>Takim A basliyor</p>
-          <button onClick={handleStart}>Basla</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleStart}>Basla</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
       {screen === 'play' && (
@@ -148,15 +160,19 @@ export default function TabooGame({ onBack }) {
         <>
           <p>Takim A skoru: {scoreA}</p>
           <p>Siradaki Takim: B</p>
-          <button onClick={handleNextTeam}>Basla</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleNextTeam}>Basla</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
       {screen === 'end' && (
         <>
           <p className="score-board">Son Skor - A: {scoreA} B: {scoreB}</p>
-          <button onClick={handleRestart}>Yeniden Oyna</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleRestart}>Yeniden Oyna</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
     </div>

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -20,6 +20,14 @@
   box-sizing: border-box;
 }
 
+.hidden-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
 @media (max-width: 600px) {
   .controls input {
     flex: 1 1 100%;

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import './WordPuzzle.css'
 import Tooltip from './Tooltip.jsx'
 
@@ -10,7 +10,6 @@ export default function WordPuzzleGame({ onBack }) {
   ].sort()
 
   const words = [
-    'ak',
     'akide',
     'bilet',
     'cihan',
@@ -19,7 +18,6 @@ export default function WordPuzzleGame({ onBack }) {
     'fidan',
     'gizem',
     'hayal',
-    'is',
     'islem',
     'kuzey',
     'lamba',
@@ -34,7 +32,6 @@ export default function WordPuzzleGame({ onBack }) {
     'yolcu',
     'zengin',
     'balon',
-    'dag',
     'eller',
     'gunes',
     'hayvan',
@@ -67,7 +64,13 @@ export default function WordPuzzleGame({ onBack }) {
   })
   const wordLen = secret.length
 
+  const inputRef = useRef(null)
+
   const finished = status !== ''
+
+  useEffect(() => {
+    if (inputRef.current) inputRef.current.focus()
+  }, [finished, wordLen])
 
   const handleHeaderClick = () => {
     const count = headerClicks + 1
@@ -152,15 +155,20 @@ export default function WordPuzzleGame({ onBack }) {
         <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>
       <p className="word-length">
-        {Array.from({ length: wordLen }).map(() => '_').join(' ')}
+        {Array.from({ length: wordLen })
+          .map((_, i) => (guess[i] ? guess[i] : '_'))
+          .join(' ')}
       </p>
       <div className="controls">
         {!finished && (
           <>
             <input
+              ref={inputRef}
+              className="hidden-input"
               value={guess}
               onChange={e => setGuess(e.target.value.toLowerCase())}
               maxLength={wordLen}
+              autoFocus
             />
             <button onClick={handleSubmit}>Tahmin</button>
             {(superMode || hintsLeft > 0) && (


### PR DESCRIPTION
## Summary
- expand Tabu card list with more words
- hide word puzzle input while still typing via hidden field
- show typed letters directly in the blank display
- ensure word puzzle words are at least 4 letters
- space out start screen controls and Tabu menu buttons
- bump app version to 0.6.0

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888fcaa9f708327871891f3eccaa9d1