### PR TITLE
Enhance word puzzle input

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.5.0</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.6.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -47,7 +47,7 @@
 .options {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   align-items: center;
   margin-bottom: 1rem;
   width: 100%;
@@ -56,7 +56,7 @@
 .options > div {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
   justify-content: space-between;
   width: 100%;
 }

--- a/src/Taboo.css
+++ b/src/Taboo.css
@@ -44,3 +44,11 @@
   background: rgba(0, 0, 0, 0.2);
   border-radius: 8px;
 }
+
+.menu-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}

--- a/src/TabooGame.jsx
+++ b/src/TabooGame.jsx
@@ -29,6 +29,16 @@ export default function TabooGame({ onBack }) {
     { word: 'televizyon', taboo: ['kumanda', 'ekran', 'kanal', 'haber', 'film'] },
     { word: 'kalabalik', taboo: ['insan', 'topluluk', 'ses', 'yogun', 'cadir'] },
     { word: 'futbol', taboo: ['top', 'gol', 'saha', 'hakem', 'takim'] },
+    { word: 'yazilim', taboo: ['kod', 'bilgisayar', 'program', 'yazmak', 'muhendis'] },
+    { word: 'market', taboo: ['alisveris', 'kasiyer', 'raf', 'sepet', 'magaza'] },
+    { word: 'egitim', taboo: ['okul', 'ogretmen', 'ders', 'ogrenci', 'sinav'] },
+    { word: 'tarih', taboo: ['gecmis', 'olay', 'kitap', 'muze', 'yil'] },
+    { word: 'saglik', taboo: ['doktor', 'hastane', 'ilac', 'hasta', 'tedavi'] },
+    { word: 'seyahat', taboo: ['gezi', 'yolculuk', 'tatil', 'otel', 'bavul'] },
+    { word: 'teknoloji', taboo: ['internet', 'cihaz', 'yeni', 'gelisim', 'akilli'] },
+    { word: 'arkadas', taboo: ['dost', 'sohbet', 'oyun', 'paylasim', 'yardim'] },
+    { word: 'sanat', taboo: ['resim', 'tiyatro', 'muzik', 'yaratici', 'sergi'] },
+    { word: 'macera', taboo: ['heyecan', 'seruven', 'film', 'risk', 'yeni'] },
   ]
 
   const [screen, setScreen] = useState('start')
@@ -122,8 +132,10 @@ export default function TabooGame({ onBack }) {
         <>
           <p className="score-board">Takim A: {scoreA} - Takim B: {scoreB}</p>
           <p>Takim A basliyor</p>
-          <button onClick={handleStart}>Basla</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleStart}>Basla</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
       {screen === 'play' && (
@@ -148,15 +160,19 @@ export default function TabooGame({ onBack }) {
         <>
           <p>Takim A skoru: {scoreA}</p>
           <p>Siradaki Takim: B</p>
-          <button onClick={handleNextTeam}>Basla</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleNextTeam}>Basla</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
       {screen === 'end' && (
         <>
           <p className="score-board">Son Skor - A: {scoreA} B: {scoreB}</p>
-          <button onClick={handleRestart}>Yeniden Oyna</button>
-          <button className="icon-btn" onClick={onBack}>🏠</button>
+          <div className="menu-buttons">
+            <button onClick={handleRestart}>Yeniden Oyna</button>
+            <button className="icon-btn" onClick={onBack}>🏠</button>
+          </div>
         </>
       )}
     </div>

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -14,17 +14,48 @@
   border-radius: 8px;
 }
 
-.controls input {
-  padding: 0.4rem;
-  font-size: 1.2rem;
-  box-sizing: border-box;
+.letter-pad {
+  margin-top: 0.5rem;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(8px);
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+  padding: 0.5rem;
 }
 
-@media (max-width: 600px) {
-  .controls input {
-    flex: 1 1 100%;
-  }
+.letter-pad button {
+  width: 100%;
+  height: 2.2rem;
+  transition: transform 0.2s;
+  border-radius: 8px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
 }
+
+.letter-pad button:disabled {
+  opacity: 0.5;
+}
+
+.letter-pad button:active {
+  transform: scale(0.95);
+}
+
+.hint-count {
+  font-size: 0.7em;
+}
+
+.word-puzzle h1 {
+  font-size: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+
 
 .letter {
   font-size: 1.5rem;

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './WordPuzzle.css'
 import Tooltip from './Tooltip.jsx'
 
@@ -10,7 +10,6 @@ export default function WordPuzzleGame({ onBack }) {
   ].sort()
 
   const words = [
-    'ak',
     'akide',
     'bilet',
     'cihan',
@@ -19,7 +18,6 @@ export default function WordPuzzleGame({ onBack }) {
     'fidan',
     'gizem',
     'hayal',
-    'is',
     'islem',
     'kuzey',
     'lamba',
@@ -34,7 +32,6 @@ export default function WordPuzzleGame({ onBack }) {
     'yolcu',
     'zengin',
     'balon',
-    'dag',
     'eller',
     'gunes',
     'hayvan',
@@ -69,6 +66,22 @@ export default function WordPuzzleGame({ onBack }) {
 
   const finished = status !== ''
 
+  useEffect(() => {
+    const handleKey = e => {
+      if (finished) return
+      const k = e.key.toLowerCase()
+      if (/^[a-z]$/.test(k)) {
+        handleLetter(k)
+      } else if (k === 'backspace') {
+        handleDelete()
+      } else if (k === 'enter') {
+        handleSubmit()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [finished, wordLen])
+
   const handleHeaderClick = () => {
     const count = headerClicks + 1
     if (count >= 5) {
@@ -101,6 +114,16 @@ export default function WordPuzzleGame({ onBack }) {
       }
     }
     return res
+  }
+
+  const handleLetter = l => {
+    if (finished || guess.length >= wordLen) return
+    setGuess(g => (g + l).slice(0, wordLen))
+  }
+
+  const handleDelete = () => {
+    if (finished) return
+    setGuess(g => g.slice(0, -1))
   }
 
   const handleSubmit = () => {
@@ -152,20 +175,17 @@ export default function WordPuzzleGame({ onBack }) {
         <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>
       <p className="word-length">
-        {Array.from({ length: wordLen }).map(() => '_').join(' ')}
+        {Array.from({ length: wordLen })
+          .map((_, i) => (guess[i] ? guess[i] : '_'))
+          .join(' ')}
       </p>
       <div className="controls">
         {!finished && (
           <>
-            <input
-              value={guess}
-              onChange={e => setGuess(e.target.value.toLowerCase())}
-              maxLength={wordLen}
-            />
             <button onClick={handleSubmit}>Tahmin</button>
             {(superMode || hintsLeft > 0) && (
               <button className="icon-btn" onClick={giveHint}>
-                💡 ({superMode ? '∞' : hintsLeft})
+                💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
               </button>
             )}
           </>
@@ -176,6 +196,25 @@ export default function WordPuzzleGame({ onBack }) {
           </button>
         )}
         <button className="icon-btn" onClick={onBack}>🏠</button>
+      </div>
+      <div className="letter-pad">
+        {Array.from('abcdefghijklmnopqrstuvwxyz').map(ch => (
+          <button
+            key={ch}
+            onPointerDown={e => e.preventDefault()}
+            disabled={finished || guess.length >= wordLen}
+            onClick={() => handleLetter(ch)}
+          >
+            {ch}
+          </button>
+        ))}
+        <button
+          onPointerDown={e => e.preventDefault()}
+          disabled={finished || guess.length === 0}
+          onClick={handleDelete}
+        >
+          {'<'}
+        </button>
       </div>
       {bestScore !== null && <p>Best Score: {bestScore}</p>}
       {status && <p className="status">{status}</p>}


### PR DESCRIPTION
## Summary
- implement custom on-screen keyboard for Word Puzzle
- listen for key presses so text immediately appears in blanks
- remove hidden input to stop the mobile keyboard
- style hint button and shrink puzzle title

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888fcaa9f708327871891f3eccaa9d1