### PR TITLE
Improve word puzzle UX and hint buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.6.0</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.7.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -374,7 +374,9 @@ export default function App() {
       <div className="lock-controls">
         {!finished && <button onClick={handleSubmit}>Tahmin Et</button>}
         {!finished && (superMode || hintsLeft > 0) && (
-          <button className="icon-btn" onClick={useHint}>💡 ({superMode ? '∞' : hintsLeft})</button>
+          <button className="icon-btn hint-btn" onClick={useHint}>
+            💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
+          </button>
         )}
         {finished && (
           <button className="icon-btn" onClick={restartLockGame}>🔄</button>

--- a/src/Kakuro.css
+++ b/src/Kakuro.css
@@ -175,6 +175,17 @@
 }
 
 
+.active-cell {
+  outline: 2px solid #2196f3;
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+}
+
+
 @media (max-width: 600px) {
   .kakuro-board th,
   .kakuro-board td {

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -358,8 +358,12 @@ export default function KakuroGame({ difficulty, onBack }) {
                 }
                 const pre = prefillSet.has(pos)
                 const wrong = errors[pos]
+                const cellClass = [
+                  wrong ? 'wrong' : '',
+                  activeCell && activeCell.r === r && activeCell.c === c ? 'active-cell' : ''
+                ].join(' ').trim()
                 return (
-                  <td key={c} className={wrong ? 'wrong' : ''}>
+                  <td key={c} className={cellClass}>
                     <input
                       data-pos={`${r}-${c}`}
                       value={val}
@@ -406,11 +410,11 @@ export default function KakuroGame({ difficulty, onBack }) {
             <button className="icon-btn" onClick={fixAllNotes}>📝</button>
           )}
           <button
-            className="icon-btn"
+            className="icon-btn hint-btn"
             onClick={giveHint}
             disabled={!superMode && hintsLeft <= 0}
           >
-            💡 ({superMode ? '∞' : hintsLeft})
+            💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
           </button>
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>

--- a/src/Sudoku.css
+++ b/src/Sudoku.css
@@ -125,9 +125,6 @@
   background: transparent;
 }
 
-.hint-count {
-  font-size: 0.7em;
-}
 .active-cell {
   outline: 2px solid #2196f3;
   animation: pulse 1s infinite;

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -446,7 +446,7 @@ export default function SudokuGame({ difficulty, onBack }) {
             <button className="icon-btn" onClick={fixAllNotes}>📝</button>
           )}
           <button
-            className="icon-btn"
+            className="icon-btn hint-btn"
             onClick={giveHint}
             disabled={!superMode && hintsLeft <= 0}
           >

--- a/src/WordPuzzle.css
+++ b/src/WordPuzzle.css
@@ -2,6 +2,19 @@
   text-align: center;
   animation: fadein 0.5s ease-in;
 }
+.info-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.info-bar span {
+  flex: 1;
+}
+.info-bar .best {
+  text-align: right;
+}
 
 .controls {
   margin-top: 0.5rem;
@@ -44,9 +57,6 @@
   transform: scale(0.95);
 }
 
-.hint-count {
-  font-size: 0.7em;
-}
 
 .word-puzzle h1 {
   font-size: 1.6rem;

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -118,7 +118,12 @@ export default function WordPuzzleGame({ onBack }) {
 
   const handleLetter = l => {
     if (finished || guess.length >= wordLen) return
-    setGuess(g => (g + l).slice(0, wordLen))
+    const newGuess = (guess + l).slice(0, wordLen)
+    if (newGuess.length === wordLen) {
+      submitGuess(newGuess)
+    } else {
+      setGuess(newGuess)
+    }
   }
 
   const handleDelete = () => {
@@ -126,12 +131,12 @@ export default function WordPuzzleGame({ onBack }) {
     setGuess(g => g.slice(0, -1))
   }
 
-  const handleSubmit = () => {
-    if (finished || guess.length !== wordLen) return
-    const colors = evaluateColors(guess)
-    const newAttempts = [...attempts, { guess, colors }]
+  const submitGuess = g => {
+    if (finished || g.length !== wordLen) return
+    const colors = evaluateColors(g)
+    const newAttempts = [...attempts, { guess: g, colors }]
     setAttempts(newAttempts)
-    if (guess === secret) {
+    if (g === secret) {
       setStatus('Tebrikler!')
       if (bestScore === null || newAttempts.length < bestScore) {
         setBestScore(newAttempts.length)
@@ -142,6 +147,8 @@ export default function WordPuzzleGame({ onBack }) {
     }
     setGuess('')
   }
+
+  const handleSubmit = () => submitGuess(guess)
 
   const giveHint = () => {
     if (finished || (!superMode && hintsLeft <= 0)) return
@@ -174,21 +181,20 @@ export default function WordPuzzleGame({ onBack }) {
         Kelime Bulmaca
         <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>
+      <div className="info-bar">
+        <span>Tahmin: {attempts.length}/6</span>
+        <span className="best">{bestScore !== null ? bestScore : '--'}</span>
+      </div>
       <p className="word-length">
         {Array.from({ length: wordLen })
           .map((_, i) => (guess[i] ? guess[i] : '_'))
           .join(' ')}
       </p>
       <div className="controls">
-        {!finished && (
-          <>
-            <button onClick={handleSubmit}>Tahmin</button>
-            {(superMode || hintsLeft > 0) && (
-              <button className="icon-btn" onClick={giveHint}>
-                💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
-              </button>
-            )}
-          </>
+        {!finished && (superMode || hintsLeft > 0) && (
+          <button className="icon-btn hint-btn" onClick={giveHint}>
+            💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
+          </button>
         )}
         {finished && (
           <button className="icon-btn" onClick={restart}>
@@ -216,7 +222,6 @@ export default function WordPuzzleGame({ onBack }) {
           {'<'}
         </button>
       </div>
-      {bestScore !== null && <p>Best Score: {bestScore}</p>}
       {status && <p className="status">{status}</p>}
       <div className="history">
         {attempts.map((a, idx) => (

--- a/src/index.css
+++ b/src/index.css
@@ -157,6 +157,13 @@ button {
   align-items: center;
   justify-content: center;
 }
+.hint-btn {
+  min-width: 3.4rem;
+}
+.hint-count {
+  font-size: 0.7em;
+  margin-left: 0.2rem;
+}
 
 .icon-btn:hover {
   border: 1px solid var(--secondary);


### PR DESCRIPTION
## Summary
- expand hint buttons across games and add `.hint-btn`
- show guess counter and best score above the word puzzle
- auto-submit a guess when the last letter is entered
- highlight the active cell in Kakuro
- bump version to 0.7.0

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688902d71cb08327b7a2804199e529e3