### PR TITLE
Add Nonogram puzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Bu proje React ile geliştirilmiş bir mini oyun setidir. Sayısal kilit, Sudoku
 Her oyunda başlık yanında bir **bilgi** simgesi bulunur. Bu simgeye tıkladığınızda yarı saydam tam ekran bir açıklama belirir. Açıklama penceresinde oyunun kuralları ve küçük hileler alfabetik sırayla listelenir. Yazılar daha küçük puntoda ve ipuçları italik olarak gösterilir. Açılan ekranın herhangi bir yerine tıklayarak kapatabilirsiniz.
 
 Sudoku oyununda üç zorluk seviyesi bulunur. Kolay seviyede 5x5 karelik mini bir Sudoku sunulur ve üç ipucu verilir. Orta seviyede 9x9 standart Sudoku daha fazla açık sayıyla gelir ve yine üç ipucu sağlanır. Zor seviyede 9x9 Sudoku daha az açık sayı içerir, üç yanılma hakkı ve tek ipucu vardır.
+Nonogram bulmacası da üç farklı boyutta oynanabilir. 5x5, 10x10 ve 15x15 tablolar için satır ve sütun ipuçları gösterilir. Karelere tıklayarak boyayabilir ya da boş bırakabilirsiniz; bu oyunda sanal klavye görünmez.
 
 Her oyunda başlığa art arda beş kez tıklarsanız **Süper Mod** aktif olur ve ipucu hakkı sınırsız hale gelir. Sudoku'da bu mod ayrıca notları otomatik düzeltme düğmesini gösterir.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import SudokuGame from './SudokuGame.jsx'
 import KakuroGame from './KakuroGame.jsx'
 import TabooGame from './TabooGame.jsx'
 import WordPuzzleGame from './WordPuzzleGame.jsx'
+import NonogramGame from './NonogramGame.jsx'
 import Tooltip from './Tooltip.jsx'
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
@@ -36,6 +37,7 @@ export default function App() {
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
   const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
   const [kakuroDifficulty, setKakuroDifficulty] = useState('easy')
+  const [nonogramDifficulty, setNonogramDifficulty] = useState('easy')
   const themeOptions = [
     { value: 'broken', label: 'Kırık Cam' },
     { value: 'earth', label: 'Toprak' },
@@ -104,6 +106,7 @@ export default function App() {
     } else {
       if (gameType === 'sudoku') setScreen('sudoku')
       else if (gameType === 'kakuro') setScreen('kakuro')
+      else if (gameType === 'nonogram') setScreen('nonogram')
       else if (gameType === 'taboo') setScreen('taboo')
       else if (gameType === 'word') setScreen('word')
     }
@@ -256,6 +259,7 @@ export default function App() {
               <option value="sudoku">Sudoku</option>
               <option value="lock">Lock Game</option>
               <option value="kakuro">Kakuro</option>
+              <option value="nonogram">Nonogram</option>
               <option value="taboo">Tabu</option>
               <option value="word">Kelime Bulmaca</option>
             </select>
@@ -299,6 +303,16 @@ export default function App() {
               </select>
             </div>
           )}
+          {gameType === 'nonogram' && (
+            <div>
+              <label>Zorluk: </label>
+              <select value={nonogramDifficulty} onChange={(e) => setNonogramDifficulty(e.target.value)}>
+                <option value="easy">5x5 Kolay</option>
+                <option value="medium">10x10 Orta</option>
+                <option value="hard">15x15 Zor</option>
+              </select>
+            </div>
+          )}
           <div>
             <label>Tema: </label>
             <select value={theme} onChange={(e) => setTheme(e.target.value)}>
@@ -335,6 +349,14 @@ export default function App() {
     return (
       <div className="app kakuro-app">
         <KakuroGame difficulty={kakuroDifficulty} onBack={handleRestart} />
+      </div>
+    )
+  }
+
+  if (screen === 'nonogram') {
+    return (
+      <div className="app kakuro-app">
+        <NonogramGame difficulty={nonogramDifficulty} onBack={handleRestart} />
       </div>
     )
   }

--- a/src/Nonogram.css
+++ b/src/Nonogram.css
@@ -1,0 +1,76 @@
+.nonogram {
+  text-align: center;
+  animation: fadein 0.5s ease-in;
+}
+
+.nonogram-board {
+  margin: 0 auto;
+  border-collapse: collapse;
+}
+
+.nonogram-board th,
+.nonogram-board td {
+  border: 1px solid #333;
+  width: 2rem;
+  height: 2rem;
+  text-align: center;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+}
+
+.nonogram-board th {
+  background: rgba(0,0,0,0.3);
+  font-size: 0.8rem;
+}
+
+.nonogram-board td {
+  background: rgba(255,255,255,0.2);
+  cursor: pointer;
+  position: relative;
+}
+
+.nonogram-board td.filled {
+  background: #000;
+}
+
+.nonogram-board td.cross::after {
+  content: '✖';
+  color: #e53935;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.col-hints {
+  vertical-align: bottom;
+  height: 4rem;
+}
+
+.col-hints div {
+  line-height: 1rem;
+}
+
+.row-hints {
+  white-space: nowrap;
+  padding-right: 0.2rem;
+}
+
+.nonogram-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0,0,0,0.2);
+  border-radius: 8px;
+}
+
+.status {
+  margin-top: 0.5rem;
+  font-weight: bold;
+}

--- a/src/NonogramGame.jsx
+++ b/src/NonogramGame.jsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import './Nonogram.css'
+import Tooltip from './Tooltip.jsx'
+
+const data = {
+  easy: {
+    size: 5,
+    solution: [
+      [0,1,1,0,0],
+      [1,0,1,0,1],
+      [1,1,1,1,1],
+      [0,1,0,1,0],
+      [1,0,0,0,1],
+    ],
+  },
+  medium: {
+    size: 10,
+    solution: [
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,0,0,0,1,1,0,0,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,0,0,1,1,0,0,0,1],
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,1,0,0,1,1,0,0,1,1],
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,1,0,0,1,1,0,0,1,1],
+      [0,0,1,1,0,0,1,1,0,0],
+    ],
+  },
+  hard: {
+    size: 15,
+    solution: [
+      [1,0,0,0,0,0,1,1,1,0,0,0,0,0,1],
+      [0,1,0,0,0,0,1,1,1,0,0,0,0,1,0],
+      [0,0,1,0,0,0,1,1,1,0,0,0,1,0,0],
+      [0,0,0,1,0,0,1,1,1,0,0,1,0,0,0],
+      [0,0,0,0,1,0,1,1,1,0,1,0,0,0,0],
+      [0,0,0,0,0,1,1,1,1,1,0,0,0,0,0],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [0,0,0,0,0,1,1,1,1,1,0,0,0,0,0],
+      [0,0,0,0,1,0,1,1,1,0,1,0,0,0,0],
+      [0,0,0,1,0,0,1,1,1,0,0,1,0,0,0],
+      [0,0,1,0,0,0,1,1,1,0,0,0,1,0,0],
+      [0,1,0,0,0,0,1,1,1,0,0,0,0,1,0],
+      [1,0,0,0,0,0,1,1,1,0,0,0,0,0,1],
+    ],
+  },
+}
+
+function getHints(line) {
+  const res = []
+  let count = 0
+  for (const v of line) {
+    if (v) count++
+    else if (count) {
+      res.push(count)
+      count = 0
+    }
+  }
+  if (count) res.push(count)
+  if (res.length === 0) res.push(0)
+  return res
+}
+
+export default function NonogramGame({ difficulty, onBack }) {
+  const cfg = data[difficulty]
+  const rowHints = cfg.solution.map(getHints)
+  const colHints = cfg.solution[0].map((_, c) =>
+    getHints(cfg.solution.map(row => row[c]))
+  )
+  const emptyBoard = () =>
+    Array.from({ length: cfg.size }, () => Array(cfg.size).fill(0))
+  const [board, setBoard] = useState(emptyBoard())
+  const [finished, setFinished] = useState(false)
+
+  const toggleCell = (r, c) => {
+    if (finished) return
+    const next = board.map(row => [...row])
+    next[r][c] = (next[r][c] + 1) % 3
+    setBoard(next)
+  }
+
+  const check = () => {
+    for (let r = 0; r < cfg.size; r++) {
+      for (let c = 0; c < cfg.size; c++) {
+        const val = board[r][c] === 1 ? 1 : 0
+        if (val !== cfg.solution[r][c]) {
+          alert('Yanlis')
+          return
+        }
+      }
+    }
+    setFinished(true)
+  }
+
+  const restart = () => {
+    setBoard(emptyBoard())
+    setFinished(false)
+  }
+
+  return (
+    <div className="nonogram">
+      <h1>
+        Nonogram
+        <Tooltip info="Satir ve sutun ipuclarina gore kareleri doldurun." tips={['Parcalar arasinda en az bir bosluk birakir','X ile bos kareleri isaretleyin','Hepsini doldurunca Kontrol butonunu kullanin']} />
+      </h1>
+      <table className="nonogram-board">
+        <thead>
+          <tr>
+            <th></th>
+            {colHints.map((col, i) => (
+              <th key={i} className="col-hints">
+                {col.map((n, j) => (
+                  <div key={j}>{n}</div>
+                ))}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {board.map((row, r) => (
+            <tr key={r}>
+              <th className="row-hints">
+                {rowHints[r].join(' ')}
+              </th>
+              {row.map((val, c) => (
+                <td
+                  key={c}
+                  className={val === 1 ? 'filled' : val === 2 ? 'cross' : ''}
+                  onClick={() => toggleCell(r, c)}
+                />
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="nonogram-controls">
+        {!finished && <button onClick={check}>Kontrol</button>}
+        {finished && <button className="icon-btn" onClick={restart}>🔄</button>}
+        <button className="icon-btn" onClick={onBack}>🏠</button>
+      </div>
+      {finished && <p className="status">Tebrikler!</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `NonogramGame` with 3 board sizes
- wire Nonogram into the main menu and game screens
- style the new puzzle
- document Nonogram in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68891ca770008327a5ed144aabc4f441