### PR TITLE
Add Nonogram hints and global super mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Bu proje React ile geliştirilmiş bir mini oyun setidir. Sayısal kilit, Sudoku
 Her oyunda başlık yanında bir **bilgi** simgesi bulunur. Bu simgeye tıkladığınızda yarı saydam tam ekran bir açıklama belirir. Açıklama penceresinde oyunun kuralları ve küçük hileler alfabetik sırayla listelenir. Yazılar daha küçük puntoda ve ipuçları italik olarak gösterilir. Açılan ekranın herhangi bir yerine tıklayarak kapatabilirsiniz.
 
 Sudoku oyununda üç zorluk seviyesi bulunur. Kolay seviyede 5x5 karelik mini bir Sudoku sunulur ve üç ipucu verilir. Orta seviyede 9x9 standart Sudoku daha fazla açık sayıyla gelir ve yine üç ipucu sağlanır. Zor seviyede 9x9 Sudoku daha az açık sayı içerir, üç yanılma hakkı ve tek ipucu vardır.
+Nonogram bulmacası da üç farklı boyutta oynanabilir. 5x5, 10x10 ve 15x15 tablolar için satır ve sütun ipuçları gösterilir. Karelere tıklayarak boyayabilir ya da boş bırakabilirsiniz; bu oyunda sanal klavye görünmez. Üç ipucu kullanılabilir ve tamamladığınız en iyi süre kaydedilir.
 
-Her oyunda başlığa art arda beş kez tıklarsanız **Süper Mod** aktif olur ve ipucu hakkı sınırsız hale gelir. Sudoku'da bu mod ayrıca notları otomatik düzeltme düğmesini gösterir.
+Süper moda geçmek için ana ekrandaki oyun ismine art arda beş kez tıklamanız yeterlidir. Bu modda ipucu limiti kalkar ve Nonogram için sınırsız ipucu verilir. Sudoku'da ayrıca notları otomatik düzeltme düğmesi görünür.
 
 Her tahmin sonrası sonuçlar renklerle gösterilir:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "0.7.0",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import SudokuGame from './SudokuGame.jsx'
 import KakuroGame from './KakuroGame.jsx'
 import TabooGame from './TabooGame.jsx'
 import WordPuzzleGame from './WordPuzzleGame.jsx'
+import NonogramGame from './NonogramGame.jsx'
 import Tooltip from './Tooltip.jsx'
 function generateSecret(length) {
   return Array.from({ length }, () => Math.floor(Math.random() * 10))
@@ -36,6 +37,7 @@ export default function App() {
   const [difficulty, setDifficulty] = useState('easy') // lock difficulty
   const [sudokuDifficulty, setSudokuDifficulty] = useState('hard')
   const [kakuroDifficulty, setKakuroDifficulty] = useState('easy')
+  const [nonogramDifficulty, setNonogramDifficulty] = useState('easy')
   const themeOptions = [
     { value: 'broken', label: 'Kırık Cam' },
     { value: 'earth', label: 'Toprak' },
@@ -104,6 +106,7 @@ export default function App() {
     } else {
       if (gameType === 'sudoku') setScreen('sudoku')
       else if (gameType === 'kakuro') setScreen('kakuro')
+      else if (gameType === 'nonogram') setScreen('nonogram')
       else if (gameType === 'taboo') setScreen('taboo')
       else if (gameType === 'word') setScreen('word')
     }
@@ -248,7 +251,7 @@ export default function App() {
   if (screen === 'start') {
     return (
       <div className="app">
-        <h1>MiniGames</h1>
+        <h1 onClick={handleHeaderClick}>MiniGames</h1>
         <div className="options">
           <div>
             <label>Oyun: </label>
@@ -256,6 +259,7 @@ export default function App() {
               <option value="sudoku">Sudoku</option>
               <option value="lock">Lock Game</option>
               <option value="kakuro">Kakuro</option>
+              <option value="nonogram">Nonogram</option>
               <option value="taboo">Tabu</option>
               <option value="word">Kelime Bulmaca</option>
             </select>
@@ -299,6 +303,16 @@ export default function App() {
               </select>
             </div>
           )}
+          {gameType === 'nonogram' && (
+            <div>
+              <label>Zorluk: </label>
+              <select value={nonogramDifficulty} onChange={(e) => setNonogramDifficulty(e.target.value)}>
+                <option value="easy">5x5 Kolay</option>
+                <option value="medium">10x10 Orta</option>
+                <option value="hard">15x15 Zor</option>
+              </select>
+            </div>
+          )}
           <div>
             <label>Tema: </label>
             <select value={theme} onChange={(e) => setTheme(e.target.value)}>
@@ -326,7 +340,11 @@ export default function App() {
   if (screen === 'sudoku') {
     return (
       <div className="app sudoku-app">
-        <SudokuGame difficulty={sudokuDifficulty} onBack={handleRestart} />
+        <SudokuGame
+          difficulty={sudokuDifficulty}
+          onBack={handleRestart}
+          superMode={superMode}
+        />
       </div>
     )
   }
@@ -334,7 +352,23 @@ export default function App() {
   if (screen === 'kakuro') {
     return (
       <div className="app kakuro-app">
-        <KakuroGame difficulty={kakuroDifficulty} onBack={handleRestart} />
+        <KakuroGame
+          difficulty={kakuroDifficulty}
+          onBack={handleRestart}
+          superMode={superMode}
+        />
+      </div>
+    )
+  }
+
+  if (screen === 'nonogram') {
+    return (
+      <div className="app kakuro-app">
+        <NonogramGame
+          difficulty={nonogramDifficulty}
+          onBack={handleRestart}
+          superMode={superMode}
+        />
       </div>
     )
   }
@@ -350,14 +384,14 @@ export default function App() {
   if (screen === 'word') {
     return (
       <div className="app kakuro-app">
-        <WordPuzzleGame onBack={handleRestart} />
+        <WordPuzzleGame onBack={handleRestart} superMode={superMode} />
       </div>
     )
   }
 
     return (
       <div className="app">
-        <h1 className="lock-title" onClick={handleHeaderClick}>
+        <h1 className="lock-title">
           {mode === 'easy' ? 'LockGame Casual' : 'Lock Game Challenge'}
           <Tooltip info="Rakamlari oklarla degistirip dogru sifreyi bulmaya calisin." tips={lockTricks} />
         </h1>

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import './Kakuro.css'
 import Tooltip from './Tooltip.jsx'
 
-export default function KakuroGame({ difficulty, onBack }) {
+export default function KakuroGame({ difficulty, onBack, superMode }) {
   const tricks = [
     'Ayni satirda tekrar etmeyin',
     'Kombinasyonlari ogrenin',
@@ -102,9 +102,8 @@ export default function KakuroGame({ difficulty, onBack }) {
     )
 
   const [board, setBoard] = useState(emptyBoard())
-  const [hintsLeft, setHintsLeft] = useState(cfg.hints)
-  const [superMode, setSuperMode] = useState(false)
-  const [headerClicks, setHeaderClicks] = useState(0)
+  const [hintsLeft, setHintsLeft] = useState(superMode ? Infinity : cfg.hints)
+  // superMode prop controls unlimited hints
   const [noteMode, setNoteMode] = useState(false)
   const [notes, setNotes] = useState(
     solution.map(row => row.map(() => []))
@@ -126,18 +125,6 @@ export default function KakuroGame({ difficulty, onBack }) {
     )
   )
 
-  const handleHeaderClick = () => {
-    const count = headerClicks + 1
-    if (count >= 5) {
-      if (!superMode) {
-        setSuperMode(true)
-        setHintsLeft(Infinity)
-      }
-      setHeaderClicks(0)
-    } else {
-      setHeaderClicks(count)
-    }
-  }
 
   const handleChange = (r, c, key) => {
     if (finished) return
@@ -327,7 +314,7 @@ export default function KakuroGame({ difficulty, onBack }) {
 
   return (
     <div className="kakuro">
-      <h1 onClick={handleHeaderClick}>
+      <h1>
         Kakuro
         <Tooltip info="Satir ve sutun toplamina gore kareleri doldurun." tips={tricks} />
       </h1>

--- a/src/Nonogram.css
+++ b/src/Nonogram.css
@@ -1,0 +1,91 @@
+.nonogram {
+  text-align: center;
+  animation: fadein 0.5s ease-in;
+}
+
+.nonogram-board {
+  margin: 0 auto;
+  border-collapse: collapse;
+}
+
+.nonogram-board th,
+.nonogram-board td {
+  border: 1px solid #333;
+  width: 2rem;
+  height: 2rem;
+  text-align: center;
+  color: #fff;
+  text-shadow: 0 0 3px #000;
+}
+
+.nonogram-board th {
+  background: rgba(0,0,0,0.3);
+  font-size: 0.8rem;
+}
+
+.nonogram-board td {
+  background: rgba(255,255,255,0.2);
+  cursor: pointer;
+  position: relative;
+}
+
+.nonogram-board td.filled {
+  background: var(--block-dark);
+}
+
+.nonogram-board td.error {
+  background: #e53935;
+}
+
+.nonogram-board td.cross::after {
+  content: '✖';
+  color: #e53935;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.col-hints {
+  vertical-align: bottom;
+  height: 4rem;
+}
+
+.col-hints div {
+  line-height: 1rem;
+}
+
+.row-hints {
+  white-space: nowrap;
+  padding-right: 0.2rem;
+}
+
+.nonogram-controls {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(0,0,0,0.2);
+  border-radius: 8px;
+}
+
+.status {
+  margin-top: 0.5rem;
+  font-weight: bold;
+}
+
+.info-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
+}
+.info-bar .best {
+  text-align: right;
+}

--- a/src/NonogramGame.jsx
+++ b/src/NonogramGame.jsx
@@ -1,0 +1,245 @@
+import { useState, useEffect } from 'react'
+import './Nonogram.css'
+import Tooltip from './Tooltip.jsx'
+
+const data = {
+  easy: {
+    size: 5,
+    solution: [
+      [0,1,1,0,0],
+      [1,0,1,0,1],
+      [1,1,1,1,1],
+      [0,1,0,1,0],
+      [1,0,0,0,1],
+    ],
+  },
+  medium: {
+    size: 10,
+    solution: [
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,0,0,0,1,1,0,0,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,0,0,1,1,0,0,0,1],
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,1,0,0,1,1,0,0,1,1],
+      [0,0,1,1,0,0,1,1,0,0],
+      [1,1,0,0,1,1,0,0,1,1],
+      [0,0,1,1,0,0,1,1,0,0],
+    ],
+  },
+  hard: {
+    size: 15,
+    solution: [
+      [1,0,0,0,0,0,1,1,1,0,0,0,0,0,1],
+      [0,1,0,0,0,0,1,1,1,0,0,0,0,1,0],
+      [0,0,1,0,0,0,1,1,1,0,0,0,1,0,0],
+      [0,0,0,1,0,0,1,1,1,0,0,1,0,0,0],
+      [0,0,0,0,1,0,1,1,1,0,1,0,0,0,0],
+      [0,0,0,0,0,1,1,1,1,1,0,0,0,0,0],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+      [0,0,0,0,0,1,1,1,1,1,0,0,0,0,0],
+      [0,0,0,0,1,0,1,1,1,0,1,0,0,0,0],
+      [0,0,0,1,0,0,1,1,1,0,0,1,0,0,0],
+      [0,0,1,0,0,0,1,1,1,0,0,0,1,0,0],
+      [0,1,0,0,0,0,1,1,1,0,0,0,0,1,0],
+      [1,0,0,0,0,0,1,1,1,0,0,0,0,0,1],
+    ],
+  },
+}
+
+function getHints(line) {
+  const res = []
+  let count = 0
+  for (const v of line) {
+    if (v) count++
+    else if (count) {
+      res.push(count)
+      count = 0
+    }
+  }
+  if (count) res.push(count)
+  if (res.length === 0) res.push(0)
+  return res
+}
+
+export default function NonogramGame({ difficulty, onBack, superMode }) {
+  const cfg = data[difficulty]
+  const rowHints = cfg.solution.map(getHints)
+  const colHints = cfg.solution[0].map((_, c) =>
+    getHints(cfg.solution.map(row => row[c]))
+  )
+  const emptyBoard = () =>
+    Array.from({ length: cfg.size }, () => Array(cfg.size).fill(0))
+  const [board, setBoard] = useState(emptyBoard())
+  const [finished, setFinished] = useState(false)
+  const [hintsLeft, setHintsLeft] = useState(superMode ? Infinity : 3)
+  const [errors, setErrors] = useState({})
+  const [painting, setPainting] = useState(false)
+  const [startTime, setStartTime] = useState(Date.now())
+  const [elapsed, setElapsed] = useState(0)
+  const [bestTime, setBestTime] = useState(() => {
+    const s = localStorage.getItem(`nonogramBest-${difficulty}`)
+    return s ? parseInt(s, 10) : null
+  })
+  const required = cfg.solution.flat().filter(v => v === 1).length
+
+  useEffect(() => {
+    if (finished) return
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - startTime) / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [startTime, finished])
+
+  useEffect(() => {
+    if (finished) {
+      const total = Math.floor((Date.now() - startTime) / 1000)
+      setElapsed(total)
+      if (bestTime === null || total < bestTime) {
+        setBestTime(total)
+        localStorage.setItem(`nonogramBest-${difficulty}`, total.toString())
+      }
+    }
+  }, [finished, bestTime, difficulty, startTime])
+
+  const applyValue = (r, c, val) => {
+    const next = board.map(row => [...row])
+    next[r][c] = val
+    const e = { ...errors }
+    if ((val === 1 && cfg.solution[r][c] !== 1) || (val !== 1 && cfg.solution[r][c] === 1 && val !== 0)) {
+      e[`${r}-${c}`] = true
+    } else {
+      delete e[`${r}-${c}`]
+    }
+    setErrors(e)
+    setBoard(next)
+    const filled = next.flat().filter(v => v === 1).length
+    if (filled === required && Object.keys(e).length === 0 && next.every((row, rr) => row.every((v, cc) => (v === 1 ? 1 : 0) === cfg.solution[rr][cc]))) {
+      setFinished(true)
+    }
+  }
+
+  const toggleCell = (r, c) => {
+    if (finished) return
+    const val = (board[r][c] + 1) % 3
+    applyValue(r, c, val)
+  }
+
+  const paintCell = (r, c) => {
+    if (finished) return
+    applyValue(r, c, 1)
+  }
+
+  const check = () => {
+    const errs = {}
+    for (let r = 0; r < cfg.size; r++) {
+      for (let c = 0; c < cfg.size; c++) {
+        const val = board[r][c] === 1 ? 1 : 0
+        if (val !== cfg.solution[r][c]) {
+          errs[`${r}-${c}`] = true
+        }
+      }
+    }
+    setErrors(errs)
+    if (Object.keys(errs).length === 0) setFinished(true)
+  }
+
+  const giveHint = () => {
+    if (finished || (!superMode && hintsLeft <= 0)) return
+    const cells = []
+    for (let r = 0; r < cfg.size; r++) {
+      for (let c = 0; c < cfg.size; c++) {
+        if (cfg.solution[r][c] === 1 && board[r][c] !== 1) cells.push([r, c])
+      }
+    }
+    if (cells.length === 0) return
+    const [r, c] = cells[Math.floor(Math.random() * cells.length)]
+    applyValue(r, c, 1)
+    if (!superMode) setHintsLeft(hintsLeft - 1)
+  }
+
+  const handlePointerDown = (r, c) => {
+    setPainting(true)
+    paintCell(r, c)
+  }
+
+  const handlePointerEnter = (r, c) => {
+    if (painting) paintCell(r, c)
+  }
+
+  const handlePointerUp = () => setPainting(false)
+
+  const restart = () => {
+    setBoard(emptyBoard())
+    setFinished(false)
+    setHintsLeft(superMode ? Infinity : 3)
+    setErrors({})
+    setStartTime(Date.now())
+    setElapsed(0)
+  }
+
+  return (
+    <div className="nonogram">
+      <h1>
+        Nonogram
+        <Tooltip info="Satir ve sutun ipuclarina gore kareleri doldurun." tips={['Parcalar arasinda en az bir bosluk birakir','X ile bos kareleri isaretleyin','Hepsini doldurunca Kontrol butonunu kullanin']} />
+      </h1>
+      <div className="info-bar">
+        <span>{`${Math.floor(elapsed / 60)}`.padStart(2, '0')}:{`${elapsed % 60}`.padStart(2, '0')}</span>
+        <span className="best">{bestTime !== null ? `${Math.floor(bestTime / 60)}`.padStart(2, '0') + ':' + `${bestTime % 60}`.padStart(2, '0') : '--:--'}</span>
+      </div>
+      <table className="nonogram-board" onPointerUp={handlePointerUp}>
+        <thead>
+          <tr>
+            <th></th>
+            {colHints.map((col, i) => (
+              <th key={i} className="col-hints">
+                {col.map((n, j) => (
+                  <div key={j}>{n}</div>
+                ))}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {board.map((row, r) => (
+            <tr key={r}>
+              <th className="row-hints">
+                {rowHints[r].join(' ')}
+              </th>
+              {row.map((val, c) => {
+                const cls = [
+                  val === 1 ? 'filled' : val === 2 ? 'cross' : '',
+                  errors[`${r}-${c}`] ? 'error' : ''
+                ].join(' ').trim()
+                return (
+                  <td
+                    key={c}
+                    className={cls}
+                    onClick={() => toggleCell(r, c)}
+                    onPointerDown={() => handlePointerDown(r, c)}
+                    onPointerEnter={() => handlePointerEnter(r, c)}
+                  />
+                )
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="nonogram-controls">
+        {!finished && (
+          <button className="icon-btn hint-btn" onClick={giveHint} disabled={!superMode && hintsLeft <= 0}>
+            💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
+          </button>
+        )}
+        {!finished && <button onClick={check}>Kontrol</button>}
+        {finished && <button className="icon-btn" onClick={restart}>🔄</button>}
+        <button className="icon-btn" onClick={onBack}>🏠</button>
+      </div>
+      {finished && <p className="status">Tebrikler!</p>}
+    </div>
+  )
+}

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -75,7 +75,7 @@ const data = {
   }
 }
 
-export default function SudokuGame({ difficulty, onBack }) {
+export default function SudokuGame({ difficulty, onBack, superMode }) {
   const tricks = [
     'Bos hucrelerde olasi rakamlari not alin',
     'Satir ve sutunlari tarayarak eksik rakamlari bulun',
@@ -96,8 +96,8 @@ export default function SudokuGame({ difficulty, onBack }) {
   }
   const [rand, setRand] = useState(() => createRandomData())
   const [board, setBoard] = useState(rand.puzzle.map(r => [...r]))
-  const [hintsLeft, setHintsLeft] = useState(cfg.hints)
-  const [superMode, setSuperMode] = useState(false)
+  const [hintsLeft, setHintsLeft] = useState(superMode ? Infinity : cfg.hints)
+  // superMode prop controls unlimited hints
   const [mistakes, setMistakes] = useState(0)
   const [noteMode, setNoteMode] = useState(false)
   const [notes, setNotes] = useState(
@@ -105,7 +105,6 @@ export default function SudokuGame({ difficulty, onBack }) {
   )
   const [activeCell, setActiveCell] = useState(null)
   const [errors, setErrors] = useState({})
-  const [headerClicks, setHeaderClicks] = useState(0)
   const [startTime, setStartTime] = useState(Date.now())
   const [elapsed, setElapsed] = useState(0)
   const [bestTime, setBestTime] = useState(() => {
@@ -273,32 +272,6 @@ export default function SudokuGame({ difficulty, onBack }) {
     if (!superMode) setHintsLeft(hintsLeft - 1)
   }
 
-  const giveFreeHint = () => {
-    if (finished) return
-    const empties = []
-    for (let r = 0; r < cfg.size; r++) {
-      for (let c = 0; c < cfg.size; c++) {
-        if (board[r][c] === 0) empties.push([r, c])
-      }
-    }
-    if (empties.length === 0) return
-    const [r, c] = empties[Math.floor(Math.random() * empties.length)]
-    const newBoard = board.map(row => [...row])
-    newBoard[r][c] = rand.solution[r][c]
-    const newPuzzle = rand.puzzle.map(row => [...row])
-    newPuzzle[r][c] = rand.solution[r][c]
-    setRand({ ...rand, puzzle: newPuzzle })
-    let newNotes = notes.map(row => row.map(n => [...n]))
-    newNotes[r][c] = []
-    newNotes = removeNotesForNumber(r, c, rand.solution[r][c], newNotes)
-    setNotes(newNotes)
-    setBoard(newBoard)
-    setErrors(prev => {
-      const e = { ...prev }
-      delete e[`${r}-${c}`]
-      return e
-    })
-  }
 
   const getAllowedDigits = (r, c) => {
     if (board[r][c] !== 0 || rand.puzzle[r][c] !== 0) return []
@@ -326,21 +299,6 @@ export default function SudokuGame({ difficulty, onBack }) {
     setNotes(newNotes)
   }
 
-
-  const handleHeaderClick = () => {
-    const count = headerClicks + 1
-    if (count >= 5) {
-      if (!superMode) {
-        setSuperMode(true)
-        setHintsLeft(Infinity)
-      }
-      giveFreeHint()
-      setHeaderClicks(0)
-    } else {
-      setHeaderClicks(count)
-    }
-  }
-
   const restartGame = () => {
     const newData = createRandomData()
     setRand(newData)
@@ -363,7 +321,7 @@ export default function SudokuGame({ difficulty, onBack }) {
 
   return (
     <div className={`sudoku${finished ? ' finished' : ''}`}>
-      <h1 onClick={handleHeaderClick}>
+      <h1>
         Sudoku
         <Tooltip info="Her satir, sutun ve blokta 1-9 arasi rakamlar tekrarsiz olmali." tips={tricks} />
       </h1>

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import './WordPuzzle.css'
 import Tooltip from './Tooltip.jsx'
 
-export default function WordPuzzleGame({ onBack }) {
+export default function WordPuzzleGame({ onBack, superMode }) {
   const tricks = [
     'Harf dagilimini inceleyin',
     'Kelimeleri capraz kontrol edin',
@@ -73,9 +73,7 @@ export default function WordPuzzleGame({ onBack }) {
   const [secret, setSecret] = useState(randomWord)
   const [guess, setGuess] = useState('')
   const [attempts, setAttempts] = useState([])
-  const [hintsLeft, setHintsLeft] = useState(1)
-  const [superMode, setSuperMode] = useState(false)
-  const [headerClicks, setHeaderClicks] = useState(0)
+  const [hintsLeft, setHintsLeft] = useState(superMode ? Infinity : 1)
   const [status, setStatus] = useState('')
   const [bestScore, setBestScore] = useState(() => {
     const s = localStorage.getItem('wordBest')
@@ -101,18 +99,6 @@ export default function WordPuzzleGame({ onBack }) {
     return () => window.removeEventListener('keydown', handleKey)
   }, [finished, wordLen])
 
-  const handleHeaderClick = () => {
-    const count = headerClicks + 1
-    if (count >= 5) {
-      if (!superMode) {
-        setSuperMode(true)
-        setHintsLeft(Infinity)
-      }
-      setHeaderClicks(0)
-    } else {
-      setHeaderClicks(count)
-    }
-  }
 
   const evaluateColors = (g) => {
     const res = Array(wordLen).fill('gray')
@@ -196,7 +182,7 @@ export default function WordPuzzleGame({ onBack }) {
 
   return (
     <div className="word-puzzle">
-      <h1 onClick={handleHeaderClick}>
+      <h1>
         Kelime Bulmaca
         <Tooltip info="Harfleri kullanarak anlamli kelimeler olusturun." tips={tricks} />
       </h1>


### PR DESCRIPTION
## Summary
- support global super mode on the start screen
- add drag painting, hints, timer and error checking to Nonogram
- color Nonogram board via palette
- pass super mode to all games and clean up header click logic
- bump version to 1.0.2 and document new behaviour

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68891ca770008327a5ed144aabc4f441