### PR TITLE
Improve nonogram interaction and mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <footer class="footer">Developed by Mustafa Evleksiz v0.7.0</footer>
+    <footer class="footer">Developed by Mustafa Evleksiz v0.8.0</footer>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minigames",
-  "version": "0.7.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minigames",
-      "version": "0.7.0",
+      "version": "1.0.3",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minigames",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/KakuroGame.jsx
+++ b/src/KakuroGame.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useMemo } from 'react'
 import './Kakuro.css'
 import Tooltip from './Tooltip.jsx'
 
+const isMobile = /Mobi|Android/i.test(navigator.userAgent)
+
 export default function KakuroGame({ difficulty, onBack, superMode }) {
   const tricks = [
     'Ayni satirda tekrar etmeyin',
@@ -355,7 +357,7 @@ export default function KakuroGame({ difficulty, onBack, superMode }) {
                       data-pos={`${r}-${c}`}
                       value={val}
                       readOnly
-                      inputMode="none"
+                      inputMode={isMobile ? 'none' : undefined}
                       disabled={pre}
                       onFocus={() => setActiveCell({ r, c })}
                       onBlur={e => {
@@ -406,7 +408,7 @@ export default function KakuroGame({ difficulty, onBack, superMode }) {
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
-      {!finished && (
+      {!finished && isMobile && (
         <div className="digit-pad">
           {Array.from({ length: 9 }, (_, i) => i + 1).map(n => (
             <button

--- a/src/Nonogram.css
+++ b/src/Nonogram.css
@@ -27,6 +27,8 @@
   background: rgba(255,255,255,0.2);
   cursor: pointer;
   position: relative;
+  user-select: none;
+  touch-action: none;
 }
 
 .nonogram-board td.filled {

--- a/src/NonogramGame.jsx
+++ b/src/NonogramGame.jsx
@@ -87,7 +87,6 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     const s = localStorage.getItem(`nonogramBest-${difficulty}`)
     return s ? parseInt(s, 10) : null
   })
-  const required = cfg.solution.flat().filter(v => v === 1).length
   const maxMistakes = 3
 
   useEffect(() => {
@@ -97,6 +96,12 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     }, 1000)
     return () => clearInterval(id)
   }, [startTime, finished])
+
+  useEffect(() => {
+    const handleUp = () => setPainting(false)
+    window.addEventListener('pointerup', handleUp)
+    return () => window.removeEventListener('pointerup', handleUp)
+  }, [])
 
   useEffect(() => {
     if (finished) {
@@ -113,7 +118,10 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     const next = board.map(row => [...row])
     next[r][c] = val
     const e = { ...errors }
-    if ((val === 1 && cfg.solution[r][c] !== 1) || (val !== 1 && cfg.solution[r][c] === 1 && val !== 0)) {
+    if (
+      (val === 1 && cfg.solution[r][c] !== 1) ||
+      (val !== 1 && cfg.solution[r][c] === 1 && val !== 0)
+    ) {
       e[`${r}-${c}`] = true
       const m = mistakes + 1
       setMistakes(m)
@@ -126,8 +134,13 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     }
     setErrors(e)
     setBoard(next)
-    const filled = next.flat().filter(v => v === 1).length
-    if (filled === required) check()
+    const solved = next.every((row, rr) =>
+      row.every((v, cc) => (v === 1 ? 1 : 0) === cfg.solution[rr][cc])
+    )
+    if (solved) {
+      setFinished(true)
+      setStatus('Tebrikler!')
+    }
   }
 
   const toggleCell = (r, c) => {
@@ -150,22 +163,6 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     }
   }
 
-  function check() {
-    const errs = {}
-    for (let r = 0; r < cfg.size; r++) {
-      for (let c = 0; c < cfg.size; c++) {
-        const val = board[r][c] === 1 ? 1 : 0
-        if (val !== cfg.solution[r][c]) {
-          errs[`${r}-${c}`] = true
-        }
-      }
-    }
-    setErrors(errs)
-    if (Object.keys(errs).length === 0) {
-      setFinished(true)
-      setStatus('Tebrikler!')
-    }
-  }
 
   const giveHint = () => {
     if (finished || (!superMode && hintsLeft <= 0)) return
@@ -181,7 +178,8 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     if (!superMode) setHintsLeft(hintsLeft - 1)
   }
 
-  const handlePointerDown = (r, c) => {
+  const handlePointerDown = (r, c, e) => {
+    e.preventDefault()
     setPainting(true)
     paintCell(r, c)
   }
@@ -208,7 +206,7 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
     <div className="nonogram">
       <h1>
         Nonogram
-        <Tooltip info="Satir ve sutun ipuclarina gore kareleri doldurun." tips={['Parcalar arasinda en az bir bosluk birakir','X ile bos kareleri isaretleyin','Hepsini doldurunca Kontrol butonunu kullanin']} />
+        <Tooltip info="Satir ve sutun ipuclarina gore kareleri doldurun." tips={['Parcalar arasinda en az bir bosluk birakir','X ile bos kareleri isaretleyin','T\u00fcm kareler dogruysa otomatik tamamlanir']} />
       </h1>
       <div className="info-bar">
         <span className="errors">Hata: {mistakes}/{maxMistakes}</span>
@@ -244,7 +242,7 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
                     key={c}
                     className={cls}
                     onClick={() => toggleCell(r, c)}
-                    onPointerDown={() => handlePointerDown(r, c)}
+                    onPointerDown={e => handlePointerDown(r, c, e)}
                     onPointerEnter={() => handlePointerEnter(r, c)}
                   />
                 )
@@ -267,7 +265,6 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
             💡 <span className="hint-count">({superMode ? '∞' : hintsLeft})</span>
           </button>
         )}
-        {!finished && <button onClick={check}>Kontrol</button>}
         {finished && <button className="icon-btn" onClick={restart}>🔄</button>}
         <button className="icon-btn" onClick={onBack}>🏠</button>
       </div>

--- a/src/SudokuGame.jsx
+++ b/src/SudokuGame.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react'
+
+const isMobile = /Mobi|Android/i.test(navigator.userAgent)
 import './Sudoku.css'
 import Tooltip from './Tooltip.jsx'
 
@@ -356,7 +358,7 @@ export default function SudokuGame({ difficulty, onBack, superMode }) {
                       value={cell === 0 ? '' : cell}
                       readOnly
                       disabled={rand.puzzle[r][c] !== 0}
-                      inputMode="none"
+                      inputMode={isMobile ? 'none' : undefined}
                       onFocus={() => setActiveCell({ r, c })}
                       onBlur={e => {
                         const next = e.relatedTarget
@@ -413,7 +415,7 @@ export default function SudokuGame({ difficulty, onBack, superMode }) {
           <button className="icon-btn" onClick={onBack}>🏠</button>
         </div>
       )}
-      {!finished && (
+      {!finished && isMobile && (
         <div className="digit-pad">
           {(() => {
             const allowed = activeCell ? getAllowedDigits(activeCell.r, activeCell.c) : []

--- a/src/WordPuzzleGame.jsx
+++ b/src/WordPuzzleGame.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import './WordPuzzle.css'
 import Tooltip from './Tooltip.jsx'
 
+const isMobile = /Mobi|Android/i.test(navigator.userAgent)
+
 export default function WordPuzzleGame({ onBack, superMode }) {
   const tricks = [
     'Harf dagilimini inceleyin',
@@ -208,6 +210,7 @@ export default function WordPuzzleGame({ onBack, superMode }) {
         )}
         <button className="icon-btn" onClick={onBack}>🏠</button>
       </div>
+      {isMobile && (
       <div className="letter-pad">
         {Array.from('abcdefghijklmnopqrstuvwxyz').map(ch => (
           <button
@@ -227,6 +230,7 @@ export default function WordPuzzleGame({ onBack, superMode }) {
           {'<'}
         </button>
       </div>
+      )}
       {status && <p className="status">{status}</p>}
       <div className="history">
         {attempts.map((a, idx) => (


### PR DESCRIPTION
## Summary
- disable text selection in nonogram cells
- detect puzzle completion automatically and remove `Kontrol` button
- end painting on global pointer up and prevent default drag
- hide letter/digit pads and mobile keyboard on desktop
- bump version numbers
- stop browser gestures interfering with drag painting in Nonogram

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688928a0d3e0832798730e5edaeb4383