### PR TITLE
Fix Nonogram drag painting

### DIFF
--- a/src/Nonogram.css
+++ b/src/Nonogram.css
@@ -6,6 +6,7 @@
 .nonogram-board {
   margin: 0 auto;
   border-collapse: collapse;
+  touch-action: none;
 }
 
 .nonogram-board th,

--- a/src/NonogramGame.jsx
+++ b/src/NonogramGame.jsx
@@ -212,7 +212,7 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
   const handlePointerDown = (r, c, e) => {
     e.preventDefault()
     setPainting(true)
-    paintCell(r, c)
+    toggleCell(r, c)
   }
 
   const handlePointerMove = e => {
@@ -285,7 +285,6 @@ export default function NonogramGame({ difficulty, onBack, superMode }) {
                       data-r={r}
                       data-c={c}
                       className={cls}
-                      onClick={() => toggleCell(r, c)}
                       onPointerDown={e => handlePointerDown(r, c, e)}
                     />
                 )


### PR DESCRIPTION
## Summary
- allow pointer events across the whole board in Nonogram
- remove click handler conflicts with drag painting
- start painting via pointerdown so single taps still toggle cells

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68893eb1e9a883279f0119b6aedb1f2c